### PR TITLE
Dev csv

### DIFF
--- a/api/tubul.h
+++ b/api/tubul.h
@@ -196,7 +196,10 @@ namespace TU {
 
 	std::optional<CSVContents> readCsv(std::string const& filename);
 	std::optional<CSVContents> readCsvFromString(std::string const& contents);
-
+	DataFrame dataFrameFromCSVFile(const std::string& filename);
+	DataFrame dataFrameFromCSVString(const std::string& csvContents);
+	DataFrame dataFrameFromCSVFile(const std::string& filename, const std::vector<std::string>& requestedColumns);
+	DataFrame dataFrameFromCSVFile(const std::string& filename, const ColumnRequest& requestedColumns);
 
 	std::string memCurrentRSS();
 	std::string memPeakRSS();

--- a/api/tubul.h
+++ b/api/tubul.h
@@ -199,6 +199,7 @@ namespace TU {
 	DataFrame dataFrameFromCSVFile(const std::string& filename);
 	DataFrame dataFrameFromCSVString(const std::string& csvContents);
 	DataFrame dataFrameFromCSVFile(const std::string& filename, const std::vector<std::string>& requestedColumns);
+	DataFrame dataFrameFromCSVString(const std::string& csvContents, const std::vector<std::string>& requestedColumns);
 	DataFrame dataFrameFromCSVFile(const std::string& filename, const ColumnRequest& requestedColumns);
 
 	std::string memCurrentRSS();

--- a/api/tubul.h
+++ b/api/tubul.h
@@ -201,6 +201,7 @@ namespace TU {
 	DataFrame dataFrameFromCSVFile(const std::string& filename, const std::vector<std::string>& requestedColumns);
 	DataFrame dataFrameFromCSVString(const std::string& csvContents, const std::vector<std::string>& requestedColumns);
 	DataFrame dataFrameFromCSVFile(const std::string& filename, const ColumnRequest& requestedColumns);
+	DataFrame dataFrameFromCSVString(const std::string& csvContents, const ColumnRequest& requestedColumns);
 
 	std::string memCurrentRSS();
 	std::string memPeakRSS();

--- a/tests/test_csv.cpp
+++ b/tests/test_csv.cpp
@@ -111,3 +111,28 @@ TEST(TUBULCSV, testDataframeString)
 	auto colD = std::get<TU::StringColumn>(df["D"]);
 	testColumn( colD, {"4","1","4"} );
 }
+
+TEST(TUBULCSV, testDataframeStringColumnsByName)
+{
+	TU::DataFrame df = TU::dataFrameFromCSVString( CSV1 ,{"B","C"});
+
+	auto colCount = df.getColCount();
+	EXPECT_EQ(colCount, 4);
+
+	auto testColumn = []( const std::vector<std::string>& col, const std::vector<std::string>& expected )
+	{
+	  EXPECT_EQ(col.size(), expected.size());
+	  bool colEqual = std::equal(col.begin(), col.end(), expected.begin() );
+	  EXPECT_EQ(colEqual, true);
+	};
+
+	auto colB = std::get<TU::StringColumn>(df["B"]);
+	testColumn( colB, {"2","3","1"} );
+
+	auto colC = std::get<TU::StringColumn>(df["C"]);
+	testColumn( colC, {"3","2","2"} );
+
+	//These columns shouldn't have data!
+	EXPECT_ANY_THROW( auto colA = std::get<TU::StringColumn>(df["A"]) );
+	EXPECT_ANY_THROW( auto colD = std::get<TU::StringColumn>(df["D"]) );
+}

--- a/tests/test_csv.cpp
+++ b/tests/test_csv.cpp
@@ -86,3 +86,28 @@ TEST(TUBULCSV, testColumnConversion)
 	for (size_t i =0; i< colD.size(); ++i)
 		EXPECT_EQ(colD[i], expected_col_d[i]);
 }
+TEST(TUBULCSV, testDataframeString)
+{
+	TU::DataFrame df = TU::dataFrameFromCSVString( CSV1 );
+
+	auto colCount = df.getColCount();
+	EXPECT_EQ(colCount, 4);
+
+	auto testColumn = []( const std::vector<std::string>& col, const std::vector<std::string>& expected )
+			{
+			  	EXPECT_EQ(col.size(), expected.size());
+			  	bool colEqual = std::equal(col.begin(), col.end(), expected.begin() );
+			  	EXPECT_EQ(colEqual, true);
+			};
+	auto colA = std::get<TU::StringColumn>(df["A"]);
+	testColumn(colA, {"1","4","3"});
+
+	auto colB = std::get<TU::StringColumn>(df["B"]);
+	testColumn( colB, {"2","3","1"} );
+
+	auto colC = std::get<TU::StringColumn>(df["C"]);
+	testColumn( colC, {"3","2","2"} );
+
+	auto colD = std::get<TU::StringColumn>(df["D"]);
+	testColumn( colD, {"4","1","4"} );
+}

--- a/tests/test_csv.cpp
+++ b/tests/test_csv.cpp
@@ -13,6 +13,26 @@ paco,4,3,2,1
 luis,3,1,2,4
 )";
 
+const TU::StringColumn expectedColAs = {"1","4","3"};
+const TU::StringColumn expectedColBs = {"2","3","1"};
+const TU::StringColumn expectedColCs = {"3","2","2"};
+const TU::StringColumn expectedColDs = {"4","1","4"};
+
+const TU::DoubleColumn expectedColAd = {1,4,3};
+const TU::DoubleColumn expectedColBd = {2,3,1};
+const TU::DoubleColumn expectedColCd = {3,2,2};
+const TU::DoubleColumn expectedColDd = {4,1,4};
+
+template <typename TubulDataColumnType>
+void testColumn(const TubulDataColumnType& col, const TubulDataColumnType& expected )
+{
+  EXPECT_EQ(col.size(), expected.size());
+  bool colEqual = std::equal(col.begin(), col.end(), expected.begin() );
+  if (!colEqual)
+	  std::cout << "Break here" << std::endl;
+  EXPECT_EQ(colEqual, true);
+};
+
 TEST(TUBULCSV, testBasicFunctionality)
 {
 	std::vector<size_t> expected   = {0, 1, 2, 3, 4};
@@ -100,39 +120,175 @@ TEST(TUBULCSV, testDataframeString)
 			  	EXPECT_EQ(colEqual, true);
 			};
 	auto colA = std::get<TU::StringColumn>(df["A"]);
-	testColumn(colA, {"1","4","3"});
+	testColumn(colA, expectedColAs);
 
 	auto colB = std::get<TU::StringColumn>(df["B"]);
-	testColumn( colB, {"2","3","1"} );
+	testColumn( colB, expectedColBs );
 
 	auto colC = std::get<TU::StringColumn>(df["C"]);
-	testColumn( colC, {"3","2","2"} );
+	testColumn( colC, expectedColCs );
 
 	auto colD = std::get<TU::StringColumn>(df["D"]);
-	testColumn( colD, {"4","1","4"} );
+	testColumn( colD, expectedColDs );
 }
 
-TEST(TUBULCSV, testDataframeStringColumnsByName)
+TEST(TUBULCSV, testDataframeStringColumnsByName1)
 {
 	TU::DataFrame df = TU::dataFrameFromCSVString( CSV1 ,{"B","C"});
 
 	auto colCount = df.getColCount();
 	EXPECT_EQ(colCount, 4);
 
-	auto testColumn = []( const std::vector<std::string>& col, const std::vector<std::string>& expected )
-	{
-	  EXPECT_EQ(col.size(), expected.size());
-	  bool colEqual = std::equal(col.begin(), col.end(), expected.begin() );
-	  EXPECT_EQ(colEqual, true);
-	};
-
 	auto colB = std::get<TU::StringColumn>(df["B"]);
-	testColumn( colB, {"2","3","1"} );
+	testColumn( colB, expectedColBs);
 
 	auto colC = std::get<TU::StringColumn>(df["C"]);
-	testColumn( colC, {"3","2","2"} );
+	testColumn( colC, expectedColCs );
 
 	//These columns shouldn't have data!
 	EXPECT_ANY_THROW( auto colA = std::get<TU::StringColumn>(df["A"]) );
 	EXPECT_ANY_THROW( auto colD = std::get<TU::StringColumn>(df["D"]) );
+}
+
+TEST(TUBULCSV, testDataframeStringColumnsByName2)
+{
+	TU::DataFrame df = TU::dataFrameFromCSVString( CSV1 ,{"A","C"});
+
+	auto colCount = df.getColCount();
+	EXPECT_EQ(colCount, 4);
+
+	auto colA = std::get<TU::StringColumn>(df["A"]);
+	testColumn( colA, expectedColAs);
+
+	auto colC = std::get<TU::StringColumn>(df["C"]);
+	testColumn( colC, expectedColCs );
+
+	//These columns shouldn't have data!
+	EXPECT_ANY_THROW( auto colB = std::get<TU::StringColumn>(df["B"]) );
+	EXPECT_ANY_THROW( auto colD = std::get<TU::StringColumn>(df["D"]) );
+}
+
+TEST(TUBULCSV, testDataframeStringColumnsByName3)
+{
+	TU::DataFrame df = TU::dataFrameFromCSVString( CSV1 ,{"B","D"});
+
+	auto colCount = df.getColCount();
+	EXPECT_EQ(colCount, 4);
+
+	auto colB = std::get<TU::StringColumn>(df["B"]);
+	testColumn( colB, expectedColBs);
+
+	auto colD = std::get<TU::StringColumn>(df["D"]);
+	testColumn( colD, expectedColDs );
+
+	//These columns shouldn't have data!
+	EXPECT_ANY_THROW( auto colA = std::get<TU::StringColumn>(df["A"]) );
+	EXPECT_ANY_THROW( auto colC = std::get<TU::StringColumn>(df["C"]) );
+}
+
+TEST(TUBULCSV, testDataframeStringColumnsByName4)
+{
+	TU::DataFrame df = TU::dataFrameFromCSVString( CSV1 ,{"C","A"});
+
+	auto colCount = df.getColCount();
+	EXPECT_EQ(colCount, 4);
+
+	auto colA = std::get<TU::StringColumn>(df["A"]);
+	testColumn( colA, expectedColAs);
+
+	auto colC = std::get<TU::StringColumn>(df["C"]);
+	testColumn( colC, expectedColCs );
+
+	//These columns shouldn't have data!
+	EXPECT_ANY_THROW( auto colB = std::get<TU::StringColumn>(df["B"]) );
+	EXPECT_ANY_THROW( auto colD = std::get<TU::StringColumn>(df["D"]) );
+}
+
+TEST(TUBULCSV, testDataframeColumnsByNameAndType1)
+{
+	TU::ColumnRequest req({
+		{"A",TU::DataType::DOUBLE},
+		{"B",TU::DataType::DOUBLE},
+		{"C",TU::DataType::DOUBLE},
+		{"D",TU::DataType::DOUBLE}
+	});
+	TU::DataFrame df = TU::dataFrameFromCSVString( CSV1 , req);
+
+	auto colCount = df.getColCount();
+	EXPECT_EQ(colCount, 4);
+
+	auto colA = std::get<TU::DoubleColumn>(df["A"]);
+	testColumn( colA, expectedColAd );
+	auto colB = std::get<TU::DoubleColumn>(df["B"]);
+	testColumn( colB, expectedColBd );
+	auto colC = std::get<TU::DoubleColumn>(df["C"]);
+	testColumn( colC, expectedColCd );
+	auto colD = std::get<TU::DoubleColumn>(df["D"]);
+	testColumn( colD, expectedColDd );
+	auto colA2 = std::get<TU::DoubleColumn>(df[0]);
+	testColumn( colA2, expectedColAd );
+	auto colB2 = std::get<TU::DoubleColumn>(df[1]);
+	testColumn( colB2, expectedColBd );
+	auto colC2 = std::get<TU::DoubleColumn>(df[2]);
+	testColumn( colC2, expectedColCd );
+	auto colD2 = std::get<TU::DoubleColumn>(df[3]);
+	testColumn( colD2, expectedColDd );
+
+	EXPECT_ANY_THROW( auto fail = std::get<TU::StringColumn>(df["B"]) );
+	EXPECT_ANY_THROW( auto fail = std::get<TU::StringColumn>(df["C"]) );
+}
+TEST(TUBULCSV, testDataframeColumnsByNameAndType2)
+{
+	TU::ColumnRequest req({
+							  {"A",TU::DataType::DOUBLE},
+							  {"D",TU::DataType::DOUBLE}
+						  });
+	TU::DataFrame df = TU::dataFrameFromCSVString( CSV1 , req);
+
+	auto colCount = df.getColCount();
+	EXPECT_EQ(colCount, 4);
+
+	auto colA = std::get<TU::DoubleColumn>(df["A"]);
+	testColumn( colA, expectedColAd );
+	auto colD = std::get<TU::DoubleColumn>(df["D"]);
+	testColumn( colD, expectedColDd );
+	auto colA2 = std::get<TU::DoubleColumn>(df[0]);
+	testColumn( colA2, expectedColAd );
+	auto colD2 = std::get<TU::DoubleColumn>(df[3]);
+	testColumn( colD2, expectedColDd );
+
+	EXPECT_ANY_THROW( auto fail = std::get<TU::StringColumn>(df["A"]) );
+	EXPECT_ANY_THROW( auto fail = std::get<TU::StringColumn>(df["B"]) );
+	EXPECT_ANY_THROW( auto fail = std::get<TU::StringColumn>(df["C"]) );
+	EXPECT_ANY_THROW( auto fail = std::get<TU::StringColumn>(df["D"]) );
+	EXPECT_ANY_THROW( auto fail = std::get<TU::DoubleColumn>(df["B"]) );
+	EXPECT_ANY_THROW( auto fail = std::get<TU::DoubleColumn>(df["C"]) );
+}
+
+TEST(TUBULCSV, testDataframeColumnsByNameAndType3)
+{
+	TU::ColumnRequest req({
+							  {"B",TU::DataType::DOUBLE},
+							  {"D",TU::DataType::STRING}
+						  });
+	TU::DataFrame df = TU::dataFrameFromCSVString( CSV1 , req);
+
+	auto colCount = df.getColCount();
+	EXPECT_EQ(colCount, 4);
+
+	auto colB = std::get<TU::DoubleColumn>(df["B"]);
+	testColumn( colB, expectedColBd );
+	auto colD = std::get<TU::StringColumn>(df["D"]);
+	testColumn( colD, expectedColDs );
+	auto colB2 = std::get<TU::DoubleColumn>(df[1]);
+	testColumn( colB2, expectedColBd );
+	auto colD2 = std::get<TU::StringColumn>(df[3]);
+	testColumn( colD2, expectedColDs );
+
+	EXPECT_ANY_THROW( auto fail = std::get<TU::StringColumn>(df["A"]) );
+	EXPECT_ANY_THROW( auto fail = std::get<TU::StringColumn>(df["B"]) );
+	EXPECT_ANY_THROW( auto fail = std::get<TU::StringColumn>(df["C"]) );
+	EXPECT_ANY_THROW( auto fail = std::get<TU::DoubleColumn>(df["A"]) );
+	EXPECT_ANY_THROW( auto fail = std::get<TU::DoubleColumn>(df["C"]) );
+	EXPECT_ANY_THROW( auto fail = std::get<TU::DoubleColumn>(df["D"]) );
 }

--- a/tubul/tubul_parse_csv.h
+++ b/tubul/tubul_parse_csv.h
@@ -25,12 +25,17 @@ struct ColumnRequest
 	using RequestsByPosition = std::vector<PositionType>;
 	using RequestsByName = std::vector<NameType>;
 
-	std::variant < std::monostate, RequestsByPosition , RequestsByName >  requests_;
+	ColumnRequest(const RequestsByPosition& req):
+		requests_(req){};
+	ColumnRequest(const RequestsByName& req):
+		requests_(req){};
 
 	size_t size() const;
 
 	ColumnRequest& add(size_t, TU::DataType);
 	ColumnRequest& add(const std::string&, TU::DataType);
+
+	std::variant < std::monostate, RequestsByPosition , RequestsByName >  requests_;
 };
 
 struct DataFrame

--- a/tubul/tubul_parse_csv.h
+++ b/tubul/tubul_parse_csv.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <unordered_map>
 #include <variant>
+#include <utility>
 
 namespace TU
 {
@@ -17,14 +18,33 @@ using IntegerColumn = std::vector<long>;
 using StringColumn = std::vector<std::string>;
 using DataColumn = std::variant<std::monostate, DoubleColumn, IntegerColumn, StringColumn>;
 
+struct ColumnRequest
+{
+	using PositionType = std::pair<size_t, TU::DataType>;
+	using NameType = std::pair<std::string, TU::DataType>;
+	using RequestsByPosition = std::vector<PositionType>;
+	using RequestsByName = std::vector<NameType>;
+
+	std::variant < std::monostate, RequestsByPosition , RequestsByName >  requests_;
+
+	size_t size() const;
+
+	ColumnRequest& add(size_t, TU::DataType);
+	ColumnRequest& add(const std::string&, TU::DataType);
+};
+
 struct DataFrame
 {
 	const DataColumn& operator[](size_t idx) const;
 	const DataColumn& operator[](const std::string& name) const;
 
+	size_t getColCount() const;
+	size_t getRowCount() const;
+
 	std::unordered_map<std::string, size_t> names_;
 	std::vector<DataType> type_;
 	std::vector<DataColumn> columns_;
+
 };
 
 struct CSVContents
@@ -53,5 +73,6 @@ struct CSVContents
 
 	std::unique_ptr<CSVRawData> impl_;
 };
+
 
 }


### PR DESCRIPTION
Agregando soporte para obtener directamente un dataframe desde un archivo csv. Aun se hace el proceso de leer csv->parsear csv en filas->convertir a columnas, pero ahora hay una funcion para hacerlo directamente. 
También se puede pedir columnas especificas, por nombre y ademas nombre/tipo. Revisar los tests para ver ejemplos.