### PR TITLE
Renaming function getDifference to elapsed for easier readability.

### DIFF
--- a/api/tubul.h
+++ b/api/tubul.h
@@ -221,8 +221,8 @@ namespace TU {
 	 * (but in seconds, even if it's calculated with high accuracy). Also you can
 	 * pass 2 TimePoints if you want to get the time between 2 timestamps
 	 */
-	double getDifference(TimePoint tp);
-	double getDifference(TimePoint tp_begin, TimePoint tp_end);
+	double elapsed(TimePoint tp);
+	double elapsed(TimePoint tp_begin, TimePoint tp_end);
 
 
     //////////

--- a/tests/test_time.cpp
+++ b/tests/test_time.cpp
@@ -15,21 +15,21 @@ TEST(TUBULTime, BasicTime)
 
 	TU::TimePoint begin = TU::now();
 	TU::TimePoint end = begin+3s;
-	EXPECT_EQ( 3, TU::getDifference(begin, end));
+	EXPECT_EQ( 3, TU::elapsed(begin, end));
 	end = begin + 5s;
-	EXPECT_EQ( 5, TU::getDifference(begin, end));
+	EXPECT_EQ( 5, TU::elapsed(begin, end));
 
 	end = begin + milliseconds (5500);
-	EXPECT_EQ( 5.5, TU::getDifference(begin, end));
+	EXPECT_EQ( 5.5, TU::elapsed(begin, end));
 
-	double spentTime = TU::getDifference(begin);
+	double spentTime = TU::elapsed(begin);
 	//Not sure about the value, but i would expect the clock to be more
 	//precise than a millisecond.
 	EXPECT_LT(spentTime, 0.001);
 
 	//After sleeping 1s, the time should be more than 1, but likely very little more
 	std::this_thread::sleep_for(seconds(1));
-	spentTime = TU::getDifference(begin);
+	spentTime = TU::elapsed(begin);
 	EXPECT_GT(spentTime, 1 );
 	EXPECT_LT(spentTime, 2 );
 }

--- a/tubul/tubul_time.cpp
+++ b/tubul/tubul_time.cpp
@@ -11,13 +11,13 @@ namespace TU
 {
 
 
-double getDifference(TimePoint tp)
+double elapsed(TimePoint tp)
 {
 	TimeDuration elapsed = (now() - tp);
 	return elapsed.count();
 }
 
-double getDifference(TimePoint tp_begin, TimePoint tp_end)
+double elapsed(TimePoint tp_begin, TimePoint tp_end)
 {
 	TimeDuration elapsed = (tp_end - tp_begin);
 	return elapsed.count();

--- a/tubul/tubul_time.h
+++ b/tubul/tubul_time.h
@@ -13,8 +13,8 @@ using TimePoint = std::chrono::high_resolution_clock::time_point;
 
 auto constexpr now = &std::chrono::high_resolution_clock::now;
 
-double getDifference(TimePoint tp);
-double getDifference(TimePoint tp_begin, TimePoint tp_end);
+double elapsed(TimePoint tp);
+double elapsed(TimePoint tp_begin, TimePoint tp_end);
 
 struct AutoStopWatch
 {


### PR DESCRIPTION
Direct rename of function (and fixage of related tests)