### PR TITLE
Helper function to iterate strings line by line

### DIFF
--- a/api/tubul.h
+++ b/api/tubul.h
@@ -82,7 +82,19 @@ namespace TU {
     template<typename IteratorType>
     std::string join(IteratorType begin, IteratorType end, std::string const &joiner);
 
-
+    /** The slinerange function will return an object that can be iterated
+     * with the range loop idiom (or using begin/end iterators if that's your
+     * style). Each item of the range is a line contained in the input string
+     * s (using "\n" as separator). If you load the contents of a text file into
+     * memory, you can iterate very easily by using slinerange. It's very similar
+     * to std::getline, but uses string_views to avoid copies and has more c++
+     * flavour imho.
+     *
+     * for ( auto line: TU::slinerange(my_string) )
+     *      std::cout << "This is a line: " << line << std::endl;
+     *
+     */
+    StringLineRange slinerange(const std::string& s);
 	////////////
 	// Logger
 	////////////

--- a/tests/test_string.cpp
+++ b/tests/test_string.cpp
@@ -6,6 +6,16 @@
 #include <algorithm>
 #include "tubul.h"
 
+const char* test_string1 = R"(This is a test
+for the line iterator
+that uses
+string views)";
+const char* test_string2 = R"(This is a test
+for the line iterator
+that uses
+string views
+)";
+
 TEST(TUBULString, testSplitEmpty){
 	std::vector<std::string> tests = {""," ", "  " } ;
 	for ( auto const& test_string: tests)
@@ -224,4 +234,37 @@ TEST(TUBULString, testJoin){
 	test = {"A","B"};
 	res = TU::join(test, "->");
 	EXPECT_EQ(res, "A->B");
+}
+
+
+TEST(TUBULString, testLineIterator) {
+
+    std::string test(test_string1);
+    std::vector<std::string> expected1 = {
+                "This is a test",
+                "for the line iterator",
+                "that uses",
+                "string views"};
+    auto range = TU::slinerange(test);
+    auto it = range.begin();
+    auto end = range.end();
+    size_t expected_id = 0;
+    while( it != end ) {
+        EXPECT_EQ(*it, expected1.at(expected_id));
+        ++it; ++expected_id;
+    }
+    expected_id = 0;
+    for (auto line: TU::slinerange(test)) {
+        EXPECT_EQ(line, expected1.at(expected_id));
+        expected_id++;
+    }
+
+    std::string test2(test_string2);
+    expected_id =0;
+    expected1.emplace_back("");
+    for (auto line: TU::slinerange(test2)) {
+        EXPECT_EQ(line, expected1.at(expected_id));
+        expected_id++;
+    }
+
 }

--- a/tubul/tubul_string.cpp
+++ b/tubul/tubul_string.cpp
@@ -10,6 +10,7 @@
 #include <string_view>
 #include <algorithm>
 #include <type_traits>
+#include "tubul_string.h"
 
 namespace TU
 {
@@ -213,4 +214,11 @@ template std::string join<std::vector<std::string_view>>(std::vector<std::string
 template std::string join<std::deque<std::string_view>>(std::deque<std::string_view> const& container, std::string const& joiner);
 template std::string join<std::list<std::string_view>>(std::list<std::string_view> const& container, std::string const& joiner);
 template std::string join<std::set<std::string_view>>(std::set<std::string_view> const& container, std::string const& joiner);
+
+
+details::string_line_range slinerange(const std::string& s)
+{
+    return details::string_line_range(s);
+}
+
 }

--- a/tubul/tubul_string.h
+++ b/tubul/tubul_string.h
@@ -50,12 +50,12 @@ namespace TU {
                         start_ = finish_ = std::string::npos;
                     } else {
                         start_ = 0;
-                        finish_ = source_.find_first_of("\n", start_);
+                        finish_ = source_.find_first_of('\n', start_);
                     }
 
                 }
 
-                explicit iter(std::string_view s, std::string::size_type p) :
+                explicit iter(std::string_view s, std::string::size_type) :
                         source_(s),
                         start_(std::string::npos),
                         finish_(std::string::npos) {

--- a/tubul/tubul_string.h
+++ b/tubul/tubul_string.h
@@ -6,6 +6,7 @@
 #pragma once
 #include <vector>
 #include <string_view>
+#include <algorithm>
 
 ////////////
 // Strings
@@ -36,4 +37,81 @@ namespace TU {
 
     template<typename IteratorType>
     std::string join(IteratorType begin, IteratorType end, std::string const &joiner);
+
+
+    namespace details {
+        class string_line_range {
+        private:
+            class iter {
+            public:
+                explicit iter(std::string_view s) :
+                        source_(s) {
+                    if (s.empty()) {
+                        start_ = finish_ = std::string::npos;
+                    } else {
+                        start_ = 0;
+                        finish_ = source_.find_first_of("\n", start_);
+                    }
+
+                }
+
+                explicit iter(std::string_view s, std::string::size_type p) :
+                        source_(s),
+                        start_(std::string::npos),
+                        finish_(std::string::npos) {
+                }
+
+                bool operator!=(iter const &other) const {
+                    return source_ != other.source_ ||
+                           start_ != other.start_ ||
+                           finish_ != other.finish_;
+                }
+
+                std::string_view operator*() const {
+                    auto real_start = source_.data() + start_;
+                    return std::string_view{real_start, finish_ - start_ };
+                }
+
+                iter &operator++() {
+                    find_next_line();
+                    return *this;
+                }
+
+            private:
+                void find_next_line() {
+                    if (finish_ == std::string::npos) {
+                        start_ = std::string::npos;
+                        return;
+                    }
+
+                    start_ = finish_ + 1;
+                    if ( start_ >= source_.size() ) {
+                        start_ = std::string::npos;
+                        finish_ = std::string::npos;
+                        return;
+                    }
+                    finish_ = source_.find_first_of('\n', start_);
+                    if (finish_ == std::string::npos)
+                        finish_ = source_.size();
+                }
+
+                std::string_view source_;
+                std::string::size_type start_;
+                std::string::size_type finish_;
+            };
+
+        public:
+            explicit string_line_range(const std::string &s) :
+                    source_(s) {}
+
+            iter begin() { return iter(source_); }
+
+            iter end() { return iter(source_, std::string::npos); }
+
+            const std::string_view source_;
+        };
+    }//namespace details
+
+    details::string_line_range slinerange(const std::string& s);
+    using StringLineRange = details::string_line_range;
 }


### PR DESCRIPTION
Created a class+wrapper function to iterate strings line by line pretty much like what getline+stringstream would achieve, but using a string and returning string_views to avoid copies.