### PR TITLE
Thread pool getWorkerId function

### DIFF
--- a/tubul/tubul_thread_pool.cpp
+++ b/tubul/tubul_thread_pool.cpp
@@ -39,6 +39,14 @@ namespace TU
         return thread_count_;
     }
 
+    std::vector<std::thread::id> ThreadPool::getPoolWorkerIds() const{
+        std::vector<std::thread::id> res;
+        for (size_t i = 0; i < thread_count_; ++i) {
+            res.push_back( threads_[i].get_id() );
+        }
+        return res;
+    }
+
     void ThreadPool::workerFn() {
         while (running_.test())
         {

--- a/tubul/tubul_thread_pool.h
+++ b/tubul/tubul_thread_pool.h
@@ -28,6 +28,9 @@ namespace TU
         [[maybe_unused]] [[nodiscard]]
         size_t threadCount() const;
 
+        [[maybe_unused]] [[nodiscard]]
+        std::vector<std::thread::id> getPoolWorkerIds() const;
+
         /**
          * @brief Push a function with zero or more arguments, but no return value, into the task queue.
          * Does not return a future, so the user must use waitForTasks() or some other method to ensure


### PR DESCRIPTION
Adding method to recover worker id from the thread pool which can then be used to create resources per thread.

Added a unit test for this.