### PR TITLE
Adding some checks to validate the existence of \r characters 

### DIFF
--- a/tubul/tubul_file_utils.cpp
+++ b/tubul/tubul_file_utils.cpp
@@ -66,7 +66,17 @@ inline T doCharConv(std::string_view s)
             return val;
         }
     }
-    throw std::invalid_argument{"Couldn't parse text correctly"};
+    //If something failed, I don't care too much about the performance
+    //of the error reporting :(
+    std::string toType;
+    if constexpr (std::is_integral_v<T>)
+        toType = "integer";
+    else if constexpr (std::is_floating_point_v<T>)
+        toType = "floating point";
+    else
+        toType = "unknown type";
+    std::string error = std::string("Couldn't parse '") + std::string(s) + "' as a " + toType + " correctly";
+    throw TU::Exception{error};
 }
 
 double strToDouble(const std::string_view& p){

--- a/tubul/tubul_string.h
+++ b/tubul/tubul_string.h
@@ -51,6 +51,8 @@ namespace TU {
                     } else {
                         start_ = 0;
                         finish_ = source_.find_first_of('\n', start_);
+                        if (finish_ >= 1 && source_[finish_-1] == '\r')
+                            finish_ -= 1;
                     }
 
                 }
@@ -80,20 +82,34 @@ namespace TU {
 
             private:
                 void find_next_line() {
+                    //If we were already past the end of the source in the current
+                    //iteration, there's no next line possible.
                     if (finish_ == std::string::npos) {
                         start_ = std::string::npos;
                         return;
                     }
 
-                    start_ = finish_ + 1;
+                    //If we had a finish_ pointing to a \r or \n, we move past it
+                    //for the next iteration, but we have to also check if the \r and
+                    //or \n were the last characters from the source.
+                    size_t fwd = 1;
+                    if ( finish_ < source_.size() and source_[finish_] == '\r' )
+                        ++fwd;
+                    start_ = finish_ + fwd;
                     if ( start_ >= source_.size() ) {
                         start_ = std::string::npos;
                         finish_ = std::string::npos;
                         return;
                     }
+
+                    //We know there are more characters after the start_ index, so we look
+                    //for the next \n available (and check if it is preceded by a \r just in
+                    // case)
                     finish_ = source_.find_first_of('\n', start_);
                     if (finish_ == std::string::npos)
                         finish_ = source_.size();
+                    else if ( source_[finish_-1] == '\r' )
+                        finish_ -= 1;
                 }
 
                 std::string_view source_;


### PR DESCRIPTION
...when creating the new line and creating a new test to validate this situation. Not sure how to prevent the loss of performance though :(

This was required to correctly process text files created in windows (for example via a python script) that contained the \r\n sequence and could cause all kind of errors