### PR TITLE
Simplifying the hash function (less templates).

### DIFF
--- a/tubul/tubul_graph.cpp
+++ b/tubul/tubul_graph.cpp
@@ -2,6 +2,7 @@
 // Created by Carlos Acosta on 21-04-23.
 //
 
+#include "tubul_types.h"
 #include "tubul_graph.h"
 #include "tubul_irange.h"
 #include "tubul_exception.h"
@@ -45,15 +46,6 @@ namespace TU::Graph {
         return true;
     }
 
-    template<typename EnumType>
-    auto toNumber(EnumType val) -> std::underlying_type_t<EnumType> {
-        return static_cast< std::underlying_type_t<EnumType> > (val);
-    }
-
-    template<typename EnumType>
-    auto toEnum( std::underlying_type_t<EnumType> val) -> EnumType {
-        return static_cast< EnumType >(val);
-    }
 
     //Namespace for functions that can be used by other more specific
     //IO methods.

--- a/tubul/tubul_types.h
+++ b/tubul/tubul_types.h
@@ -4,6 +4,8 @@
 
 #pragma once
 #include <tuple>
+#include <cstddef>
+#include <functional>
 
 namespace TU
 {
@@ -25,6 +27,23 @@ enum class RowHeaders
 	NO
 };
 
+/** Functions to work with Enumeration types, to cast them to and from
+ * the underlying type used to represent them. Useful for printing or
+ * using the enumeration as indices of vectors for example.
+ */
+template<typename EnumType>
+auto toNumber(EnumType val) -> std::underlying_type_t<EnumType> {
+    return static_cast< std::underlying_type_t<EnumType> > (val);
+}
+
+template<typename EnumType>
+auto toEnum( std::underlying_type_t<EnumType> val) -> EnumType {
+    return static_cast< EnumType >(val);
+}
+
+/** This is so any value for which we don't provide an especialization for
+ * will use std::hash as expected. Tuple objects should match the template below!.
+ */
 template <typename TT>
 struct hash
 {
@@ -47,30 +66,43 @@ namespace {
         seed ^= TU::hash<T>()(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
     }
 
-    // Recursive template code derived from Matthieu M.
-    template<class Tuple, size_t Index = std::tuple_size<Tuple>::value - 1>
-    struct HashTupleValueImpl {
-        static void apply(size_t &seed, Tuple const &tuple) {
-            HashTupleValueImpl<Tuple, Index - 1>::apply(seed, tuple);
-            hash_combine(seed, std::get<Index>(tuple));
-        }
-    };
+    /** Variadic function to calculate the hash of an arbitrary number of arguments
+     * This function will call the combiner over every parameter in the
+     * pack args. The combiner function receives seed by reference and each time it is called
+     * will call TU::hash to obtain the hash of the given parameter and combine
+     * it with the current value of seed.
+     */
+    template< typename... Args>
+    auto hashValueCalculator(const Args&... args ) -> size_t{
+        size_t seed = 0;
+        (hash_combine(seed, args), ...);
+        return seed;
+    }
 
-    template<class Tuple>
-    struct HashTupleValueImpl<Tuple, 0> {
-        static void apply(size_t &seed, Tuple const &tuple) {
-            hash_combine(seed, std::get<0>(tuple));
-        }
-    };
+    /** Variadic function needed to "catch" the type of the tuple and the
+     * parameter pack that we need to correctly instantiate hashValueCalculator. This
+     * is needed because the call of hashValueCalculator over the tuple values happens
+     * way inside std::apply/std::invokes, and when we pass hashValueCalculator without
+     * the template, std::apply will not know how solve the instantiation.
+     * Do note that we can merge hashValueCalculator inside this function by using a variadic lambda
+     * and it should work, but i don't see much point in doing that (besides proving we can)
+     */
+    template< typename... TupleArgs>
+    auto hashTupleImpl(const std::tuple<TupleArgs...>& tt) -> size_t {
+        return std::apply(hashValueCalculator<TupleArgs...>,tt);
+    }
+
 }
+
+/** Specific implementation for tuples.
+ *
+ */
 
 template<typename ... TT>
 struct hash<std::tuple<TT...>> {
     size_t
     operator()(std::tuple<TT...> const &tt) const {
-        size_t seed = 0;
-        HashTupleValueImpl<std::tuple<TT...> >::apply(seed, tt);
-        return seed;
+        return hashTupleImpl(tt);
     }
 };
 


### PR DESCRIPTION
Moving the toEnum/toNumber functions to tubul_types to make them public.