### PR TITLE
Flat set improvements

### DIFF
--- a/tests/test_custom_containers.cpp
+++ b/tests/test_custom_containers.cpp
@@ -257,3 +257,272 @@ TEST(TUBULContainers, testFlatSetFind) {
 
 
 }
+
+TEST(TUBULContainers, testFlatSetAddAtEnd) {
+    std::vector<int> toAdd1 = { 1, 2 ,3 ,4};
+    {
+        //Test empty set
+        TU::FlatSet<int> test;
+        test.add_sorted_range_at_tail(toAdd1.begin(), toAdd1.end());
+        std::vector<int> expected = toAdd1;
+        EXPECT_EQ( expected.size(), test.size());
+        auto expectedIt = expected.begin();
+        for (auto v: test )
+            EXPECT_EQ(v, *expectedIt++);
+    }
+    {
+        //Test empty set with 1 elem
+        TU::FlatSet<int> test = { 0 };
+        test.add_sorted_range_at_tail(toAdd1.begin(), toAdd1.end());
+        std::vector<int> expected = {0,1,2,3,4};
+        EXPECT_EQ( expected.size(), test.size());
+        auto expectedIt = expected.begin();
+        for (auto v: test )
+            EXPECT_EQ(v, *expectedIt++);
+    }
+
+    {
+        //Test empty set with 2+ elem
+        TU::FlatSet<int> test = { 0, -1, -10 };
+        test.add_sorted_range_at_tail(toAdd1.begin(), toAdd1.end());
+        std::vector<int> expected = {-10, -1, 0, 1, 2, 3, 4};
+        EXPECT_EQ( expected.size(), test.size());
+        auto expectedIt = expected.begin();
+        for (auto v: test )
+            EXPECT_EQ(v, *expectedIt++);
+    }
+
+    //Test if added range is not fully sorted
+    std::vector<int> toAdd2 = { 1, 4, 2, 3};
+    {
+        TU::FlatSet<int> test;
+        test.add_sorted_range_at_tail(toAdd2.begin(), toAdd2.end());
+        std::vector<int> expected = { 1, 4};
+        EXPECT_EQ( expected.size(), test.size());
+        auto expectedIt = expected.begin();
+        for (auto v: test )
+            EXPECT_EQ(v, *expectedIt++);
+    }
+    {
+        TU::FlatSet<int> test = { 0 };
+        test.add_sorted_range_at_tail(toAdd2.begin(), toAdd2.end());
+        std::vector<int> expected = { 0, 1, 4};
+        EXPECT_EQ( expected.size(), test.size());
+        auto expectedIt = expected.begin();
+        for (auto v: test )
+            EXPECT_EQ(v, *expectedIt++);
+    }
+    {
+        TU::FlatSet<int> test = { 2 };
+        test.add_sorted_range_at_tail(toAdd2.begin(), toAdd2.end());
+        std::vector<int> expected = { 2, 4};
+        EXPECT_EQ( expected.size(), test.size());
+        auto expectedIt = expected.begin();
+        for (auto v: test )
+            EXPECT_EQ(v, *expectedIt++);
+    }
+}
+
+TEST(TUBULContainers, testFlatSetAddAtHead) {
+    std::vector<int> toAdd1 = { 1, 2 ,3 ,4};
+    {
+        //Test empty set
+        TU::FlatSet<int> test;
+        test.add_sorted_range_at_head(toAdd1.begin(), toAdd1.end());
+        std::vector<int> expected = {1,2,3,4};
+        EXPECT_EQ( expected.size(), test.size());
+        auto expectedIt = expected.begin();
+        for (auto v: test )
+            EXPECT_EQ(v, *expectedIt++);
+    }
+    {
+        //Test set with 1 elem
+        TU::FlatSet<int> test = { 10 };
+        test.add_sorted_range_at_head(toAdd1.begin(), toAdd1.end());
+        std::vector<int> expected = {1,2,3,4,10};
+        EXPECT_EQ( expected.size(), test.size());
+        auto expectedIt = expected.begin();
+        for (auto v: test )
+            EXPECT_EQ(v, *expectedIt++);
+    }
+
+    {
+        //Test set with 2+ elem
+        TU::FlatSet<int> test = { 5, 7, 10 };
+        test.add_sorted_range_at_head(toAdd1.begin(), toAdd1.end());
+        std::vector<int> expected = {1,2,3,4,5,7,10};
+        EXPECT_EQ( expected.size(), test.size());
+        auto expectedIt = expected.begin();
+        for (auto v: test )
+            EXPECT_EQ(v, *expectedIt++);
+    }
+
+    //Test if source range is not fully sorted
+    std::vector<int> toAdd2 = { 1, 4, 2, 3};
+    {
+        TU::FlatSet<int> test;
+        test.add_sorted_range_at_head(toAdd2.begin(), toAdd2.end());
+        std::vector<int> expected = {1,4};
+        EXPECT_EQ( expected.size(), test.size());
+        auto expectedIt = expected.begin();
+        for (auto v: test )
+            EXPECT_EQ(v, *expectedIt++);
+    }
+    {
+        TU::FlatSet<int> test = { 10 };
+        test.add_sorted_range_at_head(toAdd2.begin(), toAdd2.end());
+        std::vector<int> expected = {1,4,10};
+        EXPECT_EQ( expected.size(), test.size());
+        auto expectedIt = expected.begin();
+        for (auto v: test )
+            EXPECT_EQ(v, *expectedIt++);
+    }
+}
+
+TEST(TUBULContainers, testFlatSetAddOverlapped) {
+    std::vector<int> toAdd1 = {4, 10, 15};
+    {
+        TU::FlatSet<int> test;
+        test.add_sorted_range_overlapped(toAdd1.begin(), toAdd1.end());
+        std::vector<int> expected = {4, 10, 15};
+        EXPECT_EQ( expected.size(), test.size());
+        auto expectedIt = expected.begin();
+        for (auto v: test )
+            EXPECT_EQ(v, *expectedIt++);
+    }
+    {
+        TU::FlatSet<int> test = { 7 };
+        test.add_sorted_range_overlapped(toAdd1.begin(), toAdd1.end());
+        std::vector<int> expected = {4, 7, 10, 15};
+        EXPECT_EQ( expected.size(), test.size());
+        auto expectedIt = expected.begin();
+        for (auto v: test )
+            EXPECT_EQ(v, *expectedIt++);
+    }
+    {
+        //Works if original elements are entwined with those being added
+        TU::FlatSet<int> test = { 7, 11 };
+        test.add_sorted_range_overlapped(toAdd1.begin(), toAdd1.end());
+        std::vector<int> expected = {4, 7, 10, 11, 15};
+        EXPECT_EQ( expected.size(), test.size());
+        auto expectedIt = expected.begin();
+        for (auto v: test )
+            EXPECT_EQ(v, *expectedIt++);
+    }
+    {
+        //Works if all original elements are BEFORE those being added
+        TU::FlatSet<int> test = { 1, 2 };
+        test.add_sorted_range_overlapped(toAdd1.begin(), toAdd1.end());
+        std::vector<int> expected = { 1, 2, 4, 10, 15};
+        EXPECT_EQ( expected.size(), test.size());
+        auto expectedIt = expected.begin();
+        for (auto v: test )
+            EXPECT_EQ(v, *expectedIt++);
+    }
+    {
+        //Works if all original elements are AFTER those being added
+        TU::FlatSet<int> test = { 20, 24 };
+        test.add_sorted_range_overlapped(toAdd1.begin(), toAdd1.end());
+        std::vector<int> expected = { 4, 10, 15, 20 ,24};
+        EXPECT_EQ( expected.size(), test.size());
+        auto expectedIt = expected.begin();
+        for (auto v: test )
+            EXPECT_EQ(v, *expectedIt++);
+    }
+}
+
+TEST(TUBULContainers, testFlatSetAddRange) {
+
+    std::vector<int> toAdd1 = {4, 10, 15};
+    {
+        TU::FlatSet<int> test;
+        test.add_sorted_range(toAdd1.begin(), toAdd1.end());
+        std::vector<int> expected = { 4, 10, 15};
+        EXPECT_EQ( expected.size(), test.size());
+        auto expectedIt = expected.begin();
+        for (auto v: test )
+            EXPECT_EQ(v, *expectedIt++);
+
+    }
+    {
+        TU::FlatSet<int> test = { 0 };
+        test.add_sorted_range(toAdd1.begin(), toAdd1.end());
+        std::vector<int> expected = { 0, 4, 10, 15};
+        EXPECT_EQ( expected.size(), test.size());
+        auto expectedIt = expected.begin();
+        for (auto v: test )
+            EXPECT_EQ(v, *expectedIt++);
+    }
+    {
+        TU::FlatSet<int> test = { 0, 2};
+        test.add_sorted_range(toAdd1.begin(), toAdd1.end());
+        std::vector<int> expected = { 0, 2, 4, 10, 15};
+        EXPECT_EQ( expected.size(), test.size());
+        auto expectedIt = expected.begin();
+        for (auto v: test )
+            EXPECT_EQ(v, *expectedIt++);
+    }
+    {
+        TU::FlatSet<int> test = { 20, 25 };
+        test.add_sorted_range(toAdd1.begin(), toAdd1.end());
+        std::vector<int> expected = { 4, 10, 15, 20, 25};
+        EXPECT_EQ( expected.size(), test.size());
+        auto expectedIt = expected.begin();
+        for (auto v: test )
+            EXPECT_EQ(v, *expectedIt++);
+    }
+    {
+        TU::FlatSet<int> test = { 0, 20, 25 };
+        test.add_sorted_range(toAdd1.begin(), toAdd1.end());
+        std::vector<int> expected = { 0, 4, 10, 15, 20, 25};
+        EXPECT_EQ( expected.size(), test.size());
+        auto expectedIt = expected.begin();
+        for (auto v: test )
+            EXPECT_EQ(v, *expectedIt++);
+    }
+    {
+        TU::FlatSet<int> test = { 0, 7, 12 };
+        test.add_sorted_range(toAdd1.begin(), toAdd1.end());
+        std::vector<int> expected = { 0, 4, 7, 10, 12, 15};
+        EXPECT_EQ( expected.size(), test.size());
+        auto expectedIt = expected.begin();
+        for (auto v: test )
+            EXPECT_EQ(v, *expectedIt++);
+    }
+    {
+        TU::FlatSet<int> test = { 0, 4, 10 };
+        test.add_sorted_range(toAdd1.begin(), toAdd1.end());
+        std::vector<int> expected = { 0, 4, 10, 15};
+        EXPECT_EQ( expected.size(), test.size());
+        auto expectedIt = expected.begin();
+        for (auto v: test )
+            EXPECT_EQ(v, *expectedIt++);
+    }
+    {
+        TU::FlatSet<int> test = { 4, 15 };
+        test.add_sorted_range(toAdd1.begin(), toAdd1.end());
+        std::vector<int> expected = { 4, 10, 15};
+        EXPECT_EQ( expected.size(), test.size());
+        auto expectedIt = expected.begin();
+        for (auto v: test )
+            EXPECT_EQ(v, *expectedIt++);
+    }
+    {
+        TU::FlatSet<int> test = { 4, 10, 15 };
+        test.add_sorted_range(toAdd1.begin(), toAdd1.end());
+        std::vector<int> expected = { 4, 10, 15};
+        EXPECT_EQ( expected.size(), test.size());
+        auto expectedIt = expected.begin();
+        for (auto v: test )
+            EXPECT_EQ(v, *expectedIt++);
+    }
+    {
+        TU::FlatSet<int> test = { 4 };
+        test.add_sorted_range(toAdd1.begin(), toAdd1.end());
+        std::vector<int> expected = { 4, 10, 15};
+        EXPECT_EQ( expected.size(), test.size());
+        auto expectedIt = expected.begin();
+        for (auto v: test )
+            EXPECT_EQ(v, *expectedIt++);
+    }
+}

--- a/tests/test_custom_containers.cpp
+++ b/tests/test_custom_containers.cpp
@@ -526,3 +526,118 @@ TEST(TUBULContainers, testFlatSetAddRange) {
             EXPECT_EQ(v, *expectedIt++);
     }
 }
+
+TEST(TUBULContainers, testFlatSetRemoveRange) {
+    const TU::FlatSet<int> initialSet = { 1, 2, 3, 4, 5 };
+    {//Not removing anything
+        auto test = initialSet;
+        std::vector<int> toRemove = {};
+        test.remove_sorted_range(toRemove.begin(), toRemove.end());
+        std::vector<int> expected = {1,2,3,4,5};
+        EXPECT_EQ( expected.size(), test.size());
+        auto expectedIt = expected.begin();
+        for (auto v: test )
+            EXPECT_EQ(v, *expectedIt++);
+    }
+    {//removing first
+        auto test = initialSet;
+        std::vector<int> toRemove = {1};
+        test.remove_sorted_range(toRemove.begin(), toRemove.end());
+        std::vector<int> expected = {2,3,4,5};
+        EXPECT_EQ( expected.size(), test.size());
+        auto expectedIt = expected.begin();
+        for (auto v: test )
+            EXPECT_EQ(v, *expectedIt++);
+    }
+    {//removing last
+        auto test = initialSet;
+        std::vector<int> toRemove = {5};
+        test.remove_sorted_range(toRemove.begin(), toRemove.end());
+        std::vector<int> expected = {1,2,3,4};
+        EXPECT_EQ( expected.size(), test.size());
+        auto expectedIt = expected.begin();
+        for (auto v: test )
+            EXPECT_EQ(v, *expectedIt++);
+    }
+    {//removing middle
+        auto test = initialSet;
+        std::vector<int> toRemove = {3};
+        test.remove_sorted_range(toRemove.begin(), toRemove.end());
+        std::vector<int> expected = {1,2,4,5};
+        EXPECT_EQ( expected.size(), test.size());
+        auto expectedIt = expected.begin();
+        for (auto v: test )
+            EXPECT_EQ(v, *expectedIt++);
+    }
+    {//removing a couple
+        auto test = initialSet;
+        std::vector<int> toRemove = {2,4};
+        test.remove_sorted_range(toRemove.begin(), toRemove.end());
+        std::vector<int> expected = {1,3,5};
+        EXPECT_EQ( expected.size(), test.size());
+        auto expectedIt = expected.begin();
+        for (auto v: test )
+            EXPECT_EQ(v, *expectedIt++);
+    }
+    {//removing all
+        auto test = initialSet;
+        std::vector<int> toRemove = {1,2,3,4,5};
+        test.remove_sorted_range(toRemove.begin(), toRemove.end());
+        std::vector<int> expected = {};
+        EXPECT_EQ( expected.size(), test.size());
+        auto expectedIt = expected.begin();
+        for (auto v: test )
+            EXPECT_EQ(v, *expectedIt++);
+    }
+    {//Non intersecting set.
+        auto test = initialSet;
+        std::vector<int> toRemove = {0};
+        test.remove_sorted_range(toRemove.begin(), toRemove.end());
+        std::vector<int> expected = {1,2,3,4,5};
+        EXPECT_EQ( expected.size(), test.size());
+        auto expectedIt = expected.begin();
+        for (auto v: test )
+            EXPECT_EQ(v, *expectedIt++);
+    }
+    {//Non intersecting set v2.
+        auto test = initialSet;
+        std::vector<int> toRemove = {9};
+        test.remove_sorted_range(toRemove.begin(), toRemove.end());
+        std::vector<int> expected = {1,2,3,4,5};
+        EXPECT_EQ( expected.size(), test.size());
+        auto expectedIt = expected.begin();
+        for (auto v: test )
+            EXPECT_EQ(v, *expectedIt++);
+    }
+    {//Overlapping but non intersecting set.
+        auto test = initialSet;
+        std::vector<int> toRemove = {0, 9};
+        test.remove_sorted_range(toRemove.begin(), toRemove.end());
+        std::vector<int> expected = {1,2,3,4,5};
+        EXPECT_EQ( expected.size(), test.size());
+        auto expectedIt = expected.begin();
+        for (auto v: test )
+            EXPECT_EQ(v, *expectedIt++);
+    }
+    {//removing a couple elements with some values outside the set.
+        auto test = initialSet;
+        std::vector<int> toRemove = {1,5,10};
+        test.remove_sorted_range(toRemove.begin(), toRemove.end());
+        std::vector<int> expected = {2,3,4};
+        EXPECT_EQ( expected.size(), test.size());
+        auto expectedIt = expected.begin();
+        for (auto v: test )
+            EXPECT_EQ(v, *expectedIt++);
+    }
+    {//removing a couple elements with some values outside the set.
+        auto test = initialSet;
+        std::vector<int> toRemove = {0,2,4,10};
+        test.remove_sorted_range(toRemove.begin(), toRemove.end());
+        std::vector<int> expected = {1,3,5};
+        EXPECT_EQ( expected.size(), test.size());
+        auto expectedIt = expected.begin();
+        for (auto v: test )
+            EXPECT_EQ(v, *expectedIt++);
+    }
+
+}

--- a/tubul/tubul_flat_set.h
+++ b/tubul/tubul_flat_set.h
@@ -297,6 +297,53 @@ namespace TU {
             add_sorted_range_overlapped(first, last);
         }
 
+        void remove_sorted_range(iterator first, iterator last) {
+            if (empty() or first == last) //Checking the easiest of cases.
+                return;
+            //Because both sets are sorted, we can try to look for the intersection range of A and B.
+            //This helps to reduce the size of B (because if B contains elements outside the range of A
+            //we dont care about them as we won't find them in A).
+
+            //We check if there's any chance of intersection between the ranges.
+            if ( *begin() > *(last-1) or *(end()-1) < *first )
+                return;
+            //We check where we may start seeing the intersection of elements.
+            auto found = std::lower_bound(begin(), end(), *first);
+            //There's no point in continue looking because elements can't intersect.
+            if (found == end())
+                return;
+            // We check the other range until which point there could be an intersection with us
+            auto endOfOtherRange = std::upper_bound(first, last, *rbegin());
+
+            auto writeIt = found;
+            auto i = found;
+            auto j = first;
+            while (i != end() and j != endOfOtherRange) {
+                //The same element from the range is in contained. We have to not store the element
+                //pointed by i, and advance both pointers
+                if (*i == *j) {
+                    ++i;
+                    ++j;
+                }
+                //Element pointed by i was smaller (i.e. not the same), so we can store it and
+                //move pointers forward.
+                else if (*i < *j) {
+                    *writeIt = *i;
+                    ++writeIt;
+                    ++i;
+                } else //element pointed by i was bigger than pointed by j
+                {
+                    ++j;
+                }
+            }
+
+            // Copy remaining elements from A if any
+            while (i < end())
+                *writeIt++ = *i++;
+
+            // Drop elements beyond what we wrote (note writeIt points to *AFTER* the last place we wrote).
+            Base::resize(std::distance(begin(), writeIt));
+        }
         //Operators that are extremely useful
         template<class V1, class C1, class A1>
         friend bool operator==(const FlatSet<V1, C1, A1> &lhs,


### PR DESCRIPTION
After using flatsets i noticed some patterns emerged that could be handled better by knowing what we want to actually do.
* Adding a bunch of *already sorted* items: Because each addition of an item can cause a bunch elements to be moved, it would be nice to do it once. By doing some pre-checks, we can do this with as little hassle as possible, for example simply appending to the end in the best of cases, or just calling an inplace_merge to work just on the areas we need to work.
* Removing a bunch of *already sorted* items: This can be done easily with a for (item: toRemove) set.erase(item), but that would cause one search over all the set each team to find it. If the items to remove are already sorted, it can be done a bit more smartly by traversing the set just once and if the sets do not intersect, maybe you can get away with not doing anything more than a couple comparisons.