### PR TITLE
Implementing a c++20 zip view (as std::ranges::zip_view is c++23).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,10 +54,17 @@ if(CCACHE_FOUND)
     set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
 endif(CCACHE_FOUND)
 
-# colors for ninja
-if (APPLE)
+# Colors in errors if possible
+include(CheckCXXCompilerFlag)
+check_cxx_compiler_flag( -fcolor-diagnostics COLOR_DIAGNOSTICS_FLAG_SUPPORTED)
+if (COLOR_DIAGNOSTICS_FLAG_SUPPORTED)
     add_compile_options (-fcolor-diagnostics)
-endif ()
+else()
+    check_cxx_compiler_flag( -fdiagnostics-color COLOR_DIAGNOSTICS_FLAG_SUPPORTED2)
+    if (COLOR_DIAGNOSTICS_FLAG_SUPPORTED2)
+        add_compile_options (-fdiagnostics-color)
+    endif()
+endif()
 
 #Adding external dependencies.
 add_subdirectory(External)

--- a/tests/test_custom_containers.cpp
+++ b/tests/test_custom_containers.cpp
@@ -199,6 +199,16 @@ TEST(TUBULContainers, testFlatSetBasic) {
         EXPECT_EQ(val, expected2[expectedIt]);
         ++expectedIt;
     }
+
+    //We can access the set items by index as a vector
+    expectedIt = 0;
+    for (size_t it = 0; it < test.size(); ++it ){
+        EXPECT_EQ(test.item(it), expected2[expectedIt]);
+        ++expectedIt;
+    }
+    //Accessing a non-existant index will throw
+    EXPECT_THROW( test.item(100), std::exception);
+
 }
 TEST(TUBULContainers, testFlatSetConstructorList) {
 

--- a/tests/test_enumerate.cpp
+++ b/tests/test_enumerate.cpp
@@ -5,10 +5,10 @@
 #include "tubul.h"
 #include <vector>
 #include <set>
+#include <deque>
 
 
-TEST(TUBULEnumerate, vector)
-{
+TEST(TUBULEnumerate, vector) {
    std::vector<char> test_vector  = { 'a', 'b', 'c', 'd', 'e'};
    std::vector<std::tuple<size_t, char>> expected = {  {0,'a'}, {1,'b'}, {2,'c'},{3,'d'},{4,'e'} };
    auto index = 0;
@@ -37,3 +37,91 @@ TEST(TUBULEnumerate, set)
     EXPECT_EQ(index,5);
 }
 
+TEST(TUBULZip, vector_set) {
+
+    std::vector<int> test_vector  = { 1,2,3,4,5};
+    std::set<char> test_set= { 'a', 'b', 'c', 'd', 'e'};
+    auto index_vec = test_vector.begin();
+    auto index_set = test_set.begin();
+    //The range can be grabbed and reused
+    auto zipped = TU::zip(test_vector, test_set);
+
+    for (const auto &[num, letter]: zipped) {
+        // std::cout <<" tuple [" << num << "," << letter << "]" << std::endl;
+        EXPECT_EQ(*index_vec, num);
+        EXPECT_EQ(*index_set, letter);
+        ++index_vec;
+        ++index_set;
+    }
+
+    //We have to reset the expected values
+    index_vec = test_vector.begin();
+    index_set = test_set.begin();
+    for (const auto &[num, letter]: zipped) {
+        // std::cout <<" tuple [" << num << "," << letter << "]" << std::endl;
+        EXPECT_EQ(*index_vec, num);
+        EXPECT_EQ(*index_set, letter);
+        ++index_vec;
+        ++index_set;
+    }
+}
+
+TEST(TUBULZip, vector_set2)
+{
+
+    std::vector<int> test_vector  = { 1,2,3,4,5,6};
+    std::set<std::string> test_set= { "first", "second", "third", "fourth"};
+    auto index_vec = test_vector.begin();
+    auto index_set = test_set.begin();
+
+    for (const auto &[num, letter]: TU::zip(test_vector, test_set)) {
+        // std::cout <<" tuple [" << num << "," << letter << "]" << std::endl;
+        EXPECT_EQ(*index_vec, num);
+        EXPECT_EQ(*index_set, letter);
+        ++index_vec;
+        ++index_set;
+    }
+}
+
+TEST(TUBULZip, vector_set3)
+{
+
+    std::vector<int> test_vector  = { 1,2,3,4,5,6};
+    std::set<std::string> test_set= { "first", "second", "third", "fourth"};
+    std::deque<char> test_deque= { 'a', 'b', 'c', 'd', 'e'};
+    auto index_vec = test_vector.begin();
+    auto index_set = test_set.begin();
+    auto index_deque = test_deque.begin();
+
+    for (const auto &[num, word, letter]: TU::zip(test_vector, test_set, test_deque)) {
+         std::cout <<" tuple [" << num << "," << word << "," << letter << "]" << std::endl;
+        EXPECT_EQ(*index_vec, num);
+        EXPECT_EQ(*index_set, word);
+        EXPECT_EQ(*index_deque, letter);
+        ++index_vec;
+        ++index_set;
+        ++index_deque;
+    }
+}
+
+TEST(TUBULZip, std_algorithm)
+{
+
+    std::vector<int> test_vector  = { 1,2,3,4,5,6};
+    std::set<std::string> test_set= { "first", "second", "third", "fourth"};
+    std::deque<char> test_deque= { 'a', 'b', 'c', 'd', 'e'};
+
+    //Do note we have to change the order of the elements in the set because
+    //it's a set, so they will look re-ordered when iterating from begin() to end().
+    std::vector<std::tuple<int, std::string, char>> expected = {
+            { 1, "first", 'a'},
+            { 2, "fourth", 'b'},
+            { 3, "second", 'c'},
+            { 4, "third", 'd'}
+        };
+
+    auto zipped = TU::zip(test_vector, test_set, test_deque);
+    //Use std::equal between the zip-view and the actual container with the expected results
+    auto equal_result = std::equal(expected.begin(), expected.end(), zipped.begin());
+    EXPECT_TRUE(equal_result);
+}

--- a/tubul/tubul_enumerate.h
+++ b/tubul/tubul_enumerate.h
@@ -4,8 +4,6 @@
 
 
 #pragma once
-#include <iostream>
-#include <string>
 #include <vector>
 #include <tuple>
 
@@ -41,6 +39,83 @@ namespace TU {
             auto end() { return iterator{ 0, std::end(iterable) }; }
         };
         return iterable_wrapper{ std::forward<T>(iterable) };
+    }
+
+
+
+    template <typename ... Args, std::size_t ... Index>
+    auto any_match_impl(std::tuple<Args...> const &lhs,
+                        std::tuple<Args...> const &rhs,
+                        std::index_sequence<Index...>) -> bool {
+        auto result = false;
+        result = (... | (std::get<Index>(lhs) == std::get<Index>(rhs)));
+        return result;
+    }
+
+    template <typename ... Args>
+    auto any_match(std::tuple<Args...> const & lhs, std::tuple<Args...> const & rhs)
+        -> bool
+    {
+        return any_match_impl(lhs, rhs, std::index_sequence_for<Args...>{});
+    }
+
+
+    //This heavily influenced by the zip view implementantion at https://github.com/alemuntoni/zip-views
+    //It follows the same idea as enumerate, but the tuple handling makes it a looot more
+    //confusing due the heavy use of ellipsis to work over all the ranges provided.
+    template <TubulIterable... T>
+    constexpr auto zip(T&& ...  iterables) {
+
+        struct zip_iterator {
+            using value_type = std::tuple<std::ranges::range_reference_t<T>...>;
+            std::tuple<std::ranges::iterator_t<T>...> iter_tuple;
+
+            auto operator++() -> zip_iterator&
+            {
+                std::apply([](auto && ... args){ ((++args), ...); }, iter_tuple);
+                return *this;
+            }
+
+            auto operator++(int) -> zip_iterator
+            {
+                auto tmp = *this;
+                ++*this;
+                return tmp;
+            }
+
+            auto operator!=(zip_iterator const & other) const
+            {
+                return not any_match(iter_tuple, other.iter_tuple);
+            }
+
+            auto operator*() -> value_type
+            {
+                return std::apply([](auto && ... args){
+                        return value_type(*args...);
+                    }, iter_tuple);
+            }
+
+        };
+        struct zipper_wrapper {
+            std::tuple<T...> iterables;
+
+            auto begin() {
+                using std::ranges::begin;
+                return std::apply([](auto &&... args) {
+                    return zip_iterator{std::make_tuple(begin(args)...)};
+                }, iterables);
+            }
+
+            auto end()
+            {
+                using std::ranges::end;
+                return std::apply([](auto && ... args){
+                    return zip_iterator{std::make_tuple(end(args)...)};
+                    }, iterables);
+            }
+        };
+
+        return zipper_wrapper{std::tie( std::forward<T>(iterables)...) };
     }
 
 

--- a/tubul/tubul_flat_set.h
+++ b/tubul/tubul_flat_set.h
@@ -117,6 +117,10 @@ namespace TU {
         reverse_iterator rend() { return Base::rend(); }
         const_reverse_iterator rend() const { return Base::rend(); }
 
+        // accessor:
+        // This breaks the illusion of being a true set, but is so useful that is worth it.
+        const value_type& item(size_type pos = 0) const { return Base::at(pos); }
+
         // capacity:
         bool empty() const { return Base::empty(); }
         size_type size() const { return Base::size(); }

--- a/tubul/tubul_graph.h
+++ b/tubul/tubul_graph.h
@@ -3,90 +3,92 @@
 //
 
 #pragma once
-#include <vector>
+#include <deque>
 #include <string>
 #include <string_view>
-#include <deque>
 #include <unordered_map>
 #include <cstdint>
+#include <vector>
 
-namespace TU::Graph {
+namespace TU::Graph
+{
 
+static constexpr char   GraphHeader[] = "%ALICANGRAPH%";
+static constexpr size_t HeaderSize    = sizeof(GraphHeader);
+using NodeId                          = int32_t;
+using CostType                        = int32_t;
 
-    static constexpr char GraphHeader[]  = "%ALICANGRAPH%";
-    static constexpr size_t HeaderSize = sizeof(GraphHeader);
-    using NodeId = std::int32_t;
-    using CostType = std::int32_t;
+struct SparseWeightDirected
+{
+	struct Edge
+	{
+		NodeId   dest_;
+		CostType cost_;
+	};
 
-    struct SparseWeightDirected {
-        struct Edge {
-            NodeId dest_;
-            CostType cost_;
-        };
+	using EdgeList      = std::vector<Edge>;
+	using NodeIdList    = std::vector<NodeId>;
+	using NodeNameList  = std::deque<std::string>;
+	using NodeNameIndex = std::unordered_map<std::string_view, size_t>;
 
-        using EdgeList = std::vector<Edge>;
-        using NodeIdList = std::vector<NodeId>;
-        using NodeNameList = std::deque<std::string>;
-        using NodeNameIndex = std::unordered_map<std::string_view, size_t>;
+	[[nodiscard]] inline size_t nodeCount() const
+	{
+		return adj_.size();
+	};
 
-        [[nodiscard]] inline
-        size_t nodeCount() const {
-            return adj_.size();
-        };
+	[[nodiscard]] inline const EdgeList &neighbors(NodeId n) const
+	{
+		return adj_.at(n);
+	}
 
-        [[nodiscard]] inline
-        const EdgeList& neighbors(NodeId n) const{
-            return adj_.at(n);
-        }
+	[[nodiscard]] inline EdgeList &neighbors(NodeId n)
+	{
+		return adj_.at(n);
+	}
 
-        [[nodiscard]] inline
-        EdgeList& neighbors(NodeId n) {
-            return adj_.at(n);
-        }
+	NodeNameList          nameTable_;
+	NodeNameIndex         nameIndex_;
+	std::vector<EdgeList> adj_;
+};
 
-        NodeNameList nameTable_;
-        NodeNameIndex nameIndex_;
-        std::vector< EdgeList > adj_;
-    };
+template <typename GraphType>
+struct GraphDescriptionInfo;
 
+template <>
+struct GraphDescriptionInfo<SparseWeightDirected>
+{
+	static const int8_t typeId = '1';
+};
 
-    template <typename GraphType>
-    struct GraphDescriptionInfo;
+bool equal(const SparseWeightDirected &l, const SparseWeightDirected &r);
+bool equal(const SparseWeightDirected::Edge &l, const SparseWeightDirected::Edge &r);
 
+namespace IO::Text
+{
+	void write(const SparseWeightDirected &g, const std::string &filename);
 
-    template<>
-    struct GraphDescriptionInfo<SparseWeightDirected>
-    {
-        static const int8_t typeId = '1';
-    };
+	SparseWeightDirected read(const std::string &filename);
+} // namespace IO::Text
 
-    bool equal(const SparseWeightDirected& l, const SparseWeightDirected& r);
-    bool equal(const SparseWeightDirected::Edge& l, const SparseWeightDirected::Edge& r);
+namespace IO::Binary
+{
+	void write(const SparseWeightDirected &g, const std::string &filename);
 
+	SparseWeightDirected read(const std::string &filename);
+} // namespace IO::Binary
 
-    namespace IO::Text {
-        void write(const SparseWeightDirected& g, const std::string& filename);
+namespace IO::Encoded
+{
+	void write(const SparseWeightDirected &g, const std::string &filename);
 
-        SparseWeightDirected read(const std::string& filename);
-    }// namespace IO::Text
+	SparseWeightDirected read(const std::string &filename);
+} // namespace IO::Encoded
 
-    namespace IO::Binary {
-        void write(const SparseWeightDirected& g, const std::string& filename);
+namespace IO::Prec
+{
+	void write(const SparseWeightDirected &g, const std::string &filename);
 
-        SparseWeightDirected read(const std::string& filename);
-    }
+	SparseWeightDirected read(const std::string &filename);
+} // namespace IO::Prec
 
-    namespace IO::Encoded{
-        void write(const SparseWeightDirected& g, const std::string& filename);
-
-        SparseWeightDirected read(const std::string& filename);
-    }
-
-    namespace IO::Prec {
-        void write(const SparseWeightDirected& g, const std::string& filename);
-
-        SparseWeightDirected read(const std::string& filename);
-    }
-
-} // TU::Graph
-
+} // namespace TU::Graph

--- a/tubul/tubul_log_types.h
+++ b/tubul/tubul_log_types.h
@@ -2,39 +2,44 @@
 
 #include <cstdint>
 
-namespace TU {
+namespace TU
+{
 
-    enum class LogLevel : uint8_t {
-        ERROR,
-        WARNING,
-        REPORT,
-        INFO,
-        DEVEL,
-        STATS,
-        DEBUG
-    };
+enum class LogLevel : uint8_t
+{
+	ERROR,
+	WARNING,
+	REPORT,
+	INFO,
+	DEVEL,
+	STATS,
+	DEBUG
+};
 
-    enum class LogOptions : uint8_t {
-        NONE = 0,
-        COLOR = 1,          // send commands for color output
-        EXCLUSIVE = 2,      // only send to specified LogLevel
-        NOTIMESTAMP = 4,    // don't prefix timestamp
-        QUIET = 8           // don't show anything
-    };
+enum class LogOptions : uint8_t
+{
+	NONE        = 0,
+	COLOR       = 1, // send commands for color output
+	EXCLUSIVE   = 2, // only send to specified LogLevel
+	NOTIMESTAMP = 4, // don't prefix timestamp
+	QUIET       = 8  // don't show anything
+};
 
-    inline LogOptions operator|(LogOptions a, LogOptions b) {
-        using underType = std::underlying_type_t<LogOptions>;
-        return static_cast<LogOptions>(static_cast<underType>(a) | static_cast<underType>(b));
-    }
-
-    inline auto operator^(LogOptions a, LogOptions b) {
-        using underType = std::underlying_type_t<LogOptions>;
-        return static_cast<underType>(static_cast<underType>(a) ^ static_cast<underType>(b));
-    }
-
-    inline auto operator&(LogOptions a, LogOptions b) {
-        using underType = std::underlying_type_t<LogOptions>;
-        return static_cast<underType>(static_cast<underType>(a) & static_cast<underType>(b));
-    }
+inline LogOptions operator|(LogOptions a, LogOptions b)
+{
+	using underType = std::underlying_type_t<LogOptions>;
+	return static_cast<LogOptions>(static_cast<underType>(a) | static_cast<underType>(b));
 }
 
+inline auto operator^(LogOptions a, LogOptions b)
+{
+	using underType = std::underlying_type_t<LogOptions>;
+	return static_cast<underType>(static_cast<underType>(a) ^ static_cast<underType>(b));
+}
+
+inline auto operator&(LogOptions a, LogOptions b)
+{
+	using underType = std::underlying_type_t<LogOptions>;
+	return static_cast<underType>(static_cast<underType>(a) & static_cast<underType>(b));
+}
+} // namespace TU


### PR DESCRIPTION
The implementation is heavily influenced by implementation from https://github.com/alemuntoni/zip-views but I tweaked it a bit to resemble enumerate, hid pieces and removed constructor (only building objects via init-lists).

Added something like the .at accessor to FlatSets for ease of use.