### PR TITLE
Zipview-implementation-linux-compilefixes

### DIFF
--- a/tubul/tubul_graph.h
+++ b/tubul/tubul_graph.h
@@ -3,89 +3,91 @@
 //
 
 #pragma once
-#include <vector>
+#include <deque>
 #include <string>
 #include <string_view>
-#include <deque>
 #include <unordered_map>
+#include <vector>
 
-namespace TU::Graph {
+namespace TU::Graph
+{
 
+static constexpr char   GraphHeader[] = "%ALICANGRAPH%";
+static constexpr size_t HeaderSize    = sizeof(GraphHeader);
+using NodeId                          = int32_t;
+using CostType                        = int32_t;
 
-    static constexpr char GraphHeader[]  = "%ALICANGRAPH%";
-    static constexpr size_t HeaderSize = sizeof(GraphHeader);
-    using NodeId = std::int32_t;
-    using CostType = std::int32_t;
+struct SparseWeightDirected
+{
+	struct Edge
+	{
+		NodeId   dest_;
+		CostType cost_;
+	};
 
-    struct SparseWeightDirected {
-        struct Edge {
-            NodeId dest_;
-            CostType cost_;
-        };
+	using EdgeList      = std::vector<Edge>;
+	using NodeIdList    = std::vector<NodeId>;
+	using NodeNameList  = std::deque<std::string>;
+	using NodeNameIndex = std::unordered_map<std::string_view, size_t>;
 
-        using EdgeList = std::vector<Edge>;
-        using NodeIdList = std::vector<NodeId>;
-        using NodeNameList = std::deque<std::string>;
-        using NodeNameIndex = std::unordered_map<std::string_view, size_t>;
+	[[nodiscard]] inline size_t nodeCount() const
+	{
+		return adj_.size();
+	};
 
-        [[nodiscard]] inline
-        size_t nodeCount() const {
-            return adj_.size();
-        };
+	[[nodiscard]] inline const EdgeList &neighbors(NodeId n) const
+	{
+		return adj_.at(n);
+	}
 
-        [[nodiscard]] inline
-        const EdgeList& neighbors(NodeId n) const{
-            return adj_.at(n);
-        }
+	[[nodiscard]] inline EdgeList &neighbors(NodeId n)
+	{
+		return adj_.at(n);
+	}
 
-        [[nodiscard]] inline
-        EdgeList& neighbors(NodeId n) {
-            return adj_.at(n);
-        }
+	NodeNameList          nameTable_;
+	NodeNameIndex         nameIndex_;
+	std::vector<EdgeList> adj_;
+};
 
-        NodeNameList nameTable_;
-        NodeNameIndex nameIndex_;
-        std::vector< EdgeList > adj_;
-    };
+template <typename GraphType>
+struct GraphDescriptionInfo;
 
+template <>
+struct GraphDescriptionInfo<SparseWeightDirected>
+{
+	static const int8_t typeId = '1';
+};
 
-    template <typename GraphType>
-    struct GraphDescriptionInfo;
+bool equal(const SparseWeightDirected &l, const SparseWeightDirected &r);
+bool equal(const SparseWeightDirected::Edge &l, const SparseWeightDirected::Edge &r);
 
+namespace IO::Text
+{
+	void write(const SparseWeightDirected &g, const std::string &filename);
 
-    template<>
-    struct GraphDescriptionInfo<SparseWeightDirected>
-    {
-        static const int8_t typeId = '1';
-    };
+	SparseWeightDirected read(const std::string &filename);
+} // namespace IO::Text
 
-    bool equal(const SparseWeightDirected& l, const SparseWeightDirected& r);
-    bool equal(const SparseWeightDirected::Edge& l, const SparseWeightDirected::Edge& r);
+namespace IO::Binary
+{
+	void write(const SparseWeightDirected &g, const std::string &filename);
 
+	SparseWeightDirected read(const std::string &filename);
+} // namespace IO::Binary
 
-    namespace IO::Text {
-        void write(const SparseWeightDirected& g, const std::string& filename);
+namespace IO::Encoded
+{
+	void write(const SparseWeightDirected &g, const std::string &filename);
 
-        SparseWeightDirected read(const std::string& filename);
-    }// namespace IO::Text
+	SparseWeightDirected read(const std::string &filename);
+} // namespace IO::Encoded
 
-    namespace IO::Binary {
-        void write(const SparseWeightDirected& g, const std::string& filename);
+namespace IO::Prec
+{
+	void write(const SparseWeightDirected &g, const std::string &filename);
 
-        SparseWeightDirected read(const std::string& filename);
-    }
+	SparseWeightDirected read(const std::string &filename);
+} // namespace IO::Prec
 
-    namespace IO::Encoded{
-        void write(const SparseWeightDirected& g, const std::string& filename);
-
-        SparseWeightDirected read(const std::string& filename);
-    }
-
-    namespace IO::Prec {
-        void write(const SparseWeightDirected& g, const std::string& filename);
-
-        SparseWeightDirected read(const std::string& filename);
-    }
-
-} // TU::Graph
-
+} // namespace TU::Graph

--- a/tubul/tubul_log_types.h
+++ b/tubul/tubul_log_types.h
@@ -1,39 +1,45 @@
 #pragma once
 
+#include <stdint.h>
 
-namespace TU {
+namespace TU
+{
 
-    enum class LogLevel : uint8_t {
-        ERROR,
-        WARNING,
-        REPORT,
-        INFO,
-        DEVEL,
-        STATS,
-        DEBUG
-    };
+enum class LogLevel : uint8_t
+{
+	ERROR,
+	WARNING,
+	REPORT,
+	INFO,
+	DEVEL,
+	STATS,
+	DEBUG
+};
 
-    enum class LogOptions : uint8_t {
-        NONE = 0,
-        COLOR = 1,          // send commands for color output
-        EXCLUSIVE = 2,      // only send to specified LogLevel
-        NOTIMESTAMP = 4,    // don't prefix timestamp
-        QUIET = 8           // don't show anything
-    };
+enum class LogOptions : uint8_t
+{
+	NONE        = 0,
+	COLOR       = 1, // send commands for color output
+	EXCLUSIVE   = 2, // only send to specified LogLevel
+	NOTIMESTAMP = 4, // don't prefix timestamp
+	QUIET       = 8  // don't show anything
+};
 
-    inline LogOptions operator|(LogOptions a, LogOptions b) {
-        using underType = std::underlying_type_t<LogOptions>;
-        return static_cast<LogOptions>(static_cast<underType>(a) | static_cast<underType>(b));
-    }
-
-    inline auto operator^(LogOptions a, LogOptions b) {
-        using underType = std::underlying_type_t<LogOptions>;
-        return static_cast<underType>(static_cast<underType>(a) ^ static_cast<underType>(b));
-    }
-
-    inline auto operator&(LogOptions a, LogOptions b) {
-        using underType = std::underlying_type_t<LogOptions>;
-        return static_cast<underType>(static_cast<underType>(a) & static_cast<underType>(b));
-    }
+inline LogOptions operator|(LogOptions a, LogOptions b)
+{
+	using underType = std::underlying_type_t<LogOptions>;
+	return static_cast<LogOptions>(static_cast<underType>(a) | static_cast<underType>(b));
 }
 
+inline auto operator^(LogOptions a, LogOptions b)
+{
+	using underType = std::underlying_type_t<LogOptions>;
+	return static_cast<underType>(static_cast<underType>(a) ^ static_cast<underType>(b));
+}
+
+inline auto operator&(LogOptions a, LogOptions b)
+{
+	using underType = std::underlying_type_t<LogOptions>;
+	return static_cast<underType>(static_cast<underType>(a) & static_cast<underType>(b));
+}
+} // namespace TU

--- a/tubul/tubul_log_types.h
+++ b/tubul/tubul_log_types.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace TU
 {


### PR DESCRIPTION
zipview-implementation is used in Solver3, but does not compile at Linux (clang18 and gcc13) because types are incorrectly used. This resolves that.