### PR TITLE
Adding a small trim lambda in rapidcsv before calling from_chars, as …

### DIFF
--- a/External/text_format_utils/include/rapidcsv.h
+++ b/External/text_format_utils/include/rapidcsv.h
@@ -163,6 +163,19 @@ namespace rapidcsv
      */
     void ToVal(const std::string& pStr, T& pVal) const
     {
+		auto quickTrim = [](const std::string &str)
+		{
+			auto beginPtr = str.begin();
+			while (*beginPtr == ' ' and beginPtr != str.end())
+				++beginPtr;
+			if ( beginPtr == str.end() )
+				return std::make_tuple(beginPtr, str.end() + str.size());
+			auto endPtr = str.begin() + str.size() -1;
+			while (*endPtr == ' ' and endPtr != beginPtr)
+				--endPtr;
+
+			return std::make_tuple(beginPtr, endPtr + 1);
+		};
       try
       {
         if constexpr ( std::is_same_v<T, int> )
@@ -217,10 +230,11 @@ namespace rapidcsv
               		  std::is_same_v<T,double>  ||
               		  std::is_same_v<T,long double> )
           {
-			  auto res = fast_float::from_chars(pStr.data(), pStr.data()+ pStr.size(), pVal);
+          	  auto [beginPtr, endPtr] = quickTrim(pStr);
+			  auto res = fast_float::from_chars(std::addressof(*beginPtr), std::addressof(*endPtr), pVal);
 			  if (res.ec != std::errc())
 			  {
-				  throw std::invalid_argument("from_chars: no conversion");
+				  throw std::invalid_argument(std::string("from_chars: no conversion for '"+pStr+"'") );
 			  }
             return;
           }
@@ -231,7 +245,8 @@ namespace rapidcsv
                std::is_same_v<T,double>  ||
               std::is_same_v<T,long double> )
           {
-			auto res = fast_float::from_chars(pStr.data(), pStr.data()+ pStr.size(), pVal);
+          	  auto [beginPtr, endPtr] = quickTrim(pStr);
+			  auto res = fast_float::from_chars(std::addressof(*beginPtr), std::addressof(*endPtr), pVal);
 			if (res.ec != std::errc())
             {
               throw std::invalid_argument("from_chars: no conversion");

--- a/tests/test_csv.cpp
+++ b/tests/test_csv.cpp
@@ -420,3 +420,48 @@ TEST(TUBULCSV, testDataframeNoColumnHeader)
 	testColumn( colD, expectedColDs );
 	testColumn(colName, expectedColNames);
 }
+
+
+
+constexpr std::string_view kBlockData = R"(X,Y,Z,value
+0, 0, 0, 1.
+0, 0, 1, 2.
+0, 0, 2, 3.
+0, 1, 0, 4.
+0, 1, 1, 5.
+0, 1, 2, 6.
+0, 2, 0, 7.
+0, 2, 1, 8.
+0, 2, 2, 9.
+1, 0, 0, 1.1
+1, 0, 1, 1.2
+1, 0, 2, 1.3
+1, 1, 0, 1.4
+1, 1, 1, 1.5
+1, 1, 2, 1.6
+1, 2, 0, 1.7
+1, 2, 1, 1.8
+1, 2, 2, 1.9
+2, 0, 0, 2.1
+2, 0, 1, 2.2
+2, 0, 2, 2.3
+2, 1, 0, 2.4
+2, 1, 1, 2.5
+2, 1, 2, 2.6
+2, 2, 0, 2.7
+2, 2, 1, 2.8
+2, 2, 2, 2.9)";
+
+TEST(
+	TUBULCSV,
+	DanielCase)
+{
+	TU::ColumnRequest req(
+			{{"X", TU::DataType::DOUBLE},
+			 {"Z", TU::DataType::DOUBLE},
+			 {"Value", TU::DataType::DOUBLE}});
+	TU::DataFrame df = TU::dataFrameFromCSVString(
+		std::string(kBlockData),req);
+	const auto& colX = std::get<TU::DoubleColumn>( df["X"]);
+	std::cout  << "First val: " << colX.at(0) << std::endl;
+}


### PR DESCRIPTION
…it is crashing in cases that include columns with spaces.