### PR TITLE
switch task queue for a task stack implemented with vectors

### DIFF
--- a/tubul/tubul_thread_pool.cpp
+++ b/tubul/tubul_thread_pool.cpp
@@ -11,6 +11,7 @@ namespace TU
             threads_(std::make_unique<std::thread[]>(thread_count_)),
             tasks_total_(0)
     {
+        tasks_.reserve(thread_count);
         running_.test_and_set();
         for (size_t i = 0; i < thread_count_; ++i)
         {
@@ -55,8 +56,8 @@ namespace TU
             task_available_cv_.wait(tasks_lock, [this] { return !tasks_.empty() || !running_.test(); });
             if (running_.test())
             {
-                task = std::move(tasks_.front());
-                tasks_.pop();
+                task = std::move(tasks_.back());
+                tasks_.pop_back();
                 tasks_lock.unlock();
                 task();
                 tasks_lock.lock();

--- a/tubul/tubul_thread_pool.h
+++ b/tubul/tubul_thread_pool.h
@@ -8,10 +8,10 @@
 #include <future>
 #include <memory>
 #include <mutex>
-#include <queue>
 #include <thread>
 #include <type_traits>
 #include <utility>
+#include <vector>
 
 namespace TU
 {
@@ -49,7 +49,7 @@ namespace TU
             std::function<void()> task_function = std::bind(std::forward<F>(task), std::forward<A>(args)...);
             {
                 const std::scoped_lock tasks_lock(tasks_mutex_);
-                tasks_.push(task_function);
+                tasks_.push_back(task_function);
             }
             ++tasks_total_;
             task_available_cv_.notify_one();
@@ -126,9 +126,9 @@ namespace TU
         std::condition_variable task_done_cv_;
 
         /**
-         * @brief A queue of tasks_ to be executed by the threads_.
+         * @brief A vector of tasks_ to be executed by the threads_.
          */
-        std::queue<std::function<void()>> tasks_ = {};
+        std::vector<std::function<void()>> tasks_ = {};
 
         /**
          * @brief A mutex to synchronize access to the task queue by different threads_.


### PR DESCRIPTION
for a thread pool object that is used repeatedly millions of times with a fixed number of tasks, the performance improves by using a vector instead of a queue for managing tasks.

compilation works and all tests pass.