### PR TITLE
Add support for repeatable arguments in argparse

### DIFF
--- a/api/tubul.h
+++ b/api/tubul.h
@@ -214,8 +214,10 @@ namespace TU {
 	 * 				.required();
 	 * 		TU::addArgument("-i", "--invitees")
 	 * 				.setAsList();
-	 * 		TU::addArgument("-v", "--verbose)
+	 * 		TU::addArgument("-v", "--verbose")
 	 * 				.flag();
+	 * 		TU::addArgument("-t", "--parameter_overload")
+	 * 				.setAsRepeatable();
 	 *
 	 * 	With parseArgsOrDie you call the argument handler to do its magic.
 	 * 	Then you can use getArg to retrieve the value of a given argument (be consistent with

--- a/tests/test_repeatable.cpp
+++ b/tests/test_repeatable.cpp
@@ -1,0 +1,46 @@
+#include <gtest/gtest.h>
+#include <vector>
+#include <string>
+#include "tubul.h"
+
+TEST(TUBULArgs, testRepeatable) {
+    // We simulate the arguments that would come from the command line
+    std::vector<const char*> argv = {
+        "test_repeatable",
+        "-t", "P1=V1",
+        "-t", "P2=V2",
+        "-v", "-v",
+        "-l", "L1", "L2",
+        "-l", "L3"
+    };
+    int argc = static_cast<int>(argv.size());
+
+    // Register arguments
+    // Note: Since the parser is global and static, this works best if 
+    // no other test has already initialized the parser with conflicting names.
+    TU::addArgument("-t", "--parameter_overload").setAsRepeatable();
+    TU::addArgument("-v", "--verbose").setAsFlag().setAsRepeatable();
+    TU::addArgument("-l", "--list").setAsList().setAsRepeatable();
+
+    // Parse the simulated arguments
+    // We use a try-catch because parseArgsOrDie might call exit() on failure 
+    // in some implementations, but here we want to verify it works.
+    TU::parseArgsOrDie(argc, argv.data());
+
+    // Verify -t (Repeatable Strings)
+    auto overloads = TU::getArg<std::vector<std::string>>("-t");
+    EXPECT_EQ(overloads.size(), 2);
+    EXPECT_EQ(overloads[0], "P1=V1");
+    EXPECT_EQ(overloads[1], "P2=V2");
+
+    // Verify -v (Repeatable Flags)
+    auto verbosity = TU::getArg<std::vector<bool>>("-v");
+    EXPECT_EQ(verbosity.size(), 2);
+
+    // Verify -l (Repeatable Lists)
+    auto lists = TU::getArg<std::vector<std::string>>("-l");
+    EXPECT_EQ(lists.size(), 3);
+    EXPECT_EQ(lists[0], "L1");
+    EXPECT_EQ(lists[1], "L2");
+    EXPECT_EQ(lists[2], "L3");
+}

--- a/tubul/tubul_argparse.cpp
+++ b/tubul/tubul_argparse.cpp
@@ -48,6 +48,7 @@ Argument& Argument::setAsDouble( ){  arg_->get().scan<'g',double>(); return *thi
 Argument& Argument::setAsInteger( ){  arg_->get().scan<'d',int>(); return *this;}
 Argument& Argument::setAsFlag(){ arg_->get().implicit_value(true).default_value(false); return *this;}
 Argument& Argument::setAsList( ){  arg_->get().nargs(argparse::nargs_pattern::at_least_one); return *this;}
+Argument& Argument::setAsRepeatable( ){  arg_->get().append(); return *this;}
 
 
 /**
@@ -118,6 +119,9 @@ template int getArg<int>(std::string const& param);
 template double getArg<double>(std::string const& param);
 template std::string getArg<std::string>(std::string const& param);
 template std::vector<std::string> getArg<std::vector<std::string>>( std::string const& param);
+template std::vector<int> getArg<std::vector<int>>( std::string const& param);
+template std::vector<double> getArg<std::vector<double>>( std::string const& param);
+template std::vector<bool> getArg<std::vector<bool>>( std::string const& param);
 
 
 
@@ -151,4 +155,7 @@ template std::optional<int> getOptionalArg<int>( std::string const& param);
 template std::optional<double> getOptionalArg<double>( std::string const& param);
 template std::optional<std::string> getOptionalArg<std::string>( std::string const& param);
 template std::optional<std::vector<std::string>> getOptionalArg<std::vector<std::string>>( std::string const& param);
+template std::optional<std::vector<int>> getOptionalArg<std::vector<int>>( std::string const& param);
+template std::optional<std::vector<double>> getOptionalArg<std::vector<double>>( std::string const& param);
+template std::optional<std::vector<bool>> getOptionalArg<std::vector<bool>>( std::string const& param);
 }

--- a/tubul/tubul_argparse.h
+++ b/tubul/tubul_argparse.h
@@ -29,6 +29,7 @@ public:
 	Argument& setAsDouble();
 	Argument& setAsInteger();
 	Argument& setAsList();
+	Argument& setAsRepeatable();
 
 private:
 	ArgImplPtr arg_;


### PR DESCRIPTION
Add support for repeatable arguments in argparse

- Implement setAsRepeatable() in TU::Argument to support multiple occurrences of the same argument.
- Add template instantiations for getArg and getOptionalArg to support vectors of int, double, and bool.
- Update public API documentation in tubul.h with usage examples.
- Add test case 'test_repeatable.cpp' to verify the new functionality.