### PR TITLE
Bugfix in zip view

### DIFF
--- a/tests/test_enumerate.cpp
+++ b/tests/test_enumerate.cpp
@@ -161,6 +161,51 @@ TEST(TUBULZip, vector_set3)
     }
 }
 
+TEST(TUBULZip, by_value_ranges)
+{
+	//Ranges that compute their elements on the fly (e.g. a transform returning
+	//by value) yield prvalues when dereferenced. Zip used to force const& tuple
+	//elements, which for those ranges bound to temporaries already dead when the
+	//loop body ran (reading garbage). Now prvalue elements are held by value,
+	//while lvalue-yielding ranges (real containers) keep the cheap const&.
+	auto squares = std::views::iota(0, 5) | std::views::transform([](int i) { return i * i; });
+	auto minus = std::views::iota(0, 5) | std::views::transform([](int i) { return static_cast<int64_t>(-1 - i); });
+
+	//Type-level check. This is the deterministic part of the regression test:
+	//reading through a dangling ref could still produce the right value by luck.
+	auto zipped = TU::zip(squares, minus);
+	using ZippedTuple = decltype(*zipped.begin());
+	static_assert(std::is_same_v<std::tuple_element_t<0, ZippedTuple>, int>,
+		"a prvalue-yielding range must be held by value");
+	static_assert(std::is_same_v<std::tuple_element_t<1, ZippedTuple>, int64_t>,
+		"a prvalue-yielding range must be held by value");
+
+	auto index = 0;
+	for (const auto& [sq, neg] : zipped) {
+		EXPECT_EQ(sq, index * index);
+		EXPECT_EQ(neg, -1 - index);
+		++index;
+	}
+	EXPECT_EQ(index, 5);
+
+	//Mixing a real container with an on-the-fly range: the container side must
+	//still be a reference (no copies), the computed side a value.
+	std::vector<std::string> words = { "zero", "one", "two", "three", "four" };
+	auto mixed = TU::zip(words, squares);
+	using MixedTuple = decltype(*mixed.begin());
+	static_assert(std::is_same_v<std::tuple_element_t<0, MixedTuple>, const std::string&>,
+		"an lvalue-yielding range must keep being a reference");
+	static_assert(std::is_same_v<std::tuple_element_t<1, MixedTuple>, int>);
+
+	index = 0;
+	for (const auto& [word, sq] : mixed) {
+		EXPECT_EQ(word, words[index]);
+		EXPECT_EQ(sq, index * index);
+		++index;
+	}
+	EXPECT_EQ(index, 5);
+}
+
 TEST(TUBULZip, std_algorithm)
 {
 

--- a/tubul/tubul_enumerate.h
+++ b/tubul/tubul_enumerate.h
@@ -55,8 +55,16 @@ namespace TU {
 			//ensure we are getting a real const-ref to the underlying item of each range.
 			//For this we will do the following template trickery
 			// get the range_reference_t ->  remove the ref -> add const to the type -> add a ref.
-			// using value_type        = std::tuple<std::ranges::range_reference_t<T&>...>;
-			using value_type = std::tuple<std::add_lvalue_reference_t<std::add_const_t<std::remove_reference_t< std::ranges::range_reference_t<T&>>>>...>;
+			// BUT only when the range actually yields lvalues: ranges that compute their
+			// elements on the fly (e.g. transform views returning by value) yield prvalues,
+			// and binding a const& tuple element to those would dangle as soon as the
+			// full-expression of operator* ends. For those we store the element by value.
+			template <typename Ref>
+			using element_t = std::conditional_t<
+				std::is_lvalue_reference_v<Ref>,
+				std::add_lvalue_reference_t<std::add_const_t<std::remove_reference_t<Ref>>>,
+				std::remove_cvref_t<Ref>>;
+			using value_type = std::tuple<element_t<std::ranges::range_reference_t<T&>>...>;
 			using reference         = value_type;
 			using iterator_category = std::input_iterator_tag;
 			using difference_type   = std::ptrdiff_t;


### PR DESCRIPTION
The current implementation was forcing a ref element when doing *. This causes issues in cases where the underlying view returns by value, for example something that creates tuples on the fly. The current impl adds a conditional type to handle this.

Added test to show the problem that is being fixed