### PR TITLE
Add SmallVector and PODVector without SBO. 

### DIFF
--- a/tests/test_podvector.cpp
+++ b/tests/test_podvector.cpp
@@ -12,49 +12,43 @@ struct Point {
 
 using TU::PODVector;
 
-TEST(PODVectorTest, testPODVectorBasics) { 
-    // Create an empty vec
-    PODVector<int, 4> vec;
+TEST(PODVectorTest, testPODVectorBasics) {
+    // Create an empty vec: no inline storage, so it owns nothing yet
+    PODVector<int> vec;
     EXPECT_TRUE(vec.empty());
     EXPECT_EQ(vec.size(), 0);
-    EXPECT_EQ(vec.capacity(), 4);
-    EXPECT_TRUE(vec.is_small());
+    EXPECT_EQ(vec.capacity(), 0);
 
-    // Push elements and confirm the new items, size and capacity
+    // Push elements and confirm the new items and size. With no SBO the buffer
+    // grows on every push until it has room to apply the 1.5 factor: 0,1,2,3,4
     for(size_t i = 0; i < 4; i++) vec.push_back(i);
     for(size_t i = 0; i < 4; i++) EXPECT_EQ(vec[i], i);
     EXPECT_EQ(vec.size(), 4);
-    EXPECT_TRUE(vec.is_small());
     EXPECT_EQ(vec.capacity(), 4);
 
     // Front and back working
     EXPECT_EQ(vec.front(), 0);
     EXPECT_EQ(vec.back(), 3);
-    
-    // Buffer changes from stack to capacity when the capacity is not enough
-    vec.push_back(4);
-    EXPECT_FALSE(vec.is_small());
-    EXPECT_EQ(vec.size(), 5);
-    EXPECT_EQ(vec.capacity(), 6); // new_capacity = 4 + 4/2 = 6
 
-    // Expect the new capacity with 1.5 factor
+    // Growth follows the 1.5 factor once there is capacity to grow from
+    vec.push_back(4);
+    EXPECT_EQ(vec.size(), 5);
+    EXPECT_EQ(vec.capacity(), 6); // next_capacity = 4 + 4/2 = 6
+
     vec.push_back(5);
     vec.push_back(6);
     EXPECT_EQ(vec.size(), 7);
-    EXPECT_EQ(vec.capacity(), 9); // new_capacity = 6 + 6/2 = 9
+    EXPECT_EQ(vec.capacity(), 9); // next_capacity = 6 + 6/2 = 9
 
-    // Capacity doesn't change with pop_backs 
-    // the vector shouldn't be small because the capacity is still 9
+    // Capacity doesn't change with pop_backs
     for(size_t i = 0; i < 3; i++) vec.pop_back();
     EXPECT_EQ(vec.size(), 4);
-    EXPECT_FALSE(vec.is_small());
     EXPECT_EQ(vec.capacity(), 9);
 
-    // The clear is working
+    // The clear keeps the capacity
     vec.clear();
     EXPECT_EQ(vec.size(), 0);
     EXPECT_TRUE(vec.empty());
-    EXPECT_FALSE(vec.is_small());
     EXPECT_EQ(vec.capacity(), 9);
 
     // Pop back with 0 elements does nothing
@@ -74,53 +68,55 @@ TEST(PODVectorTest, testPODVectorBasics) {
     for(size_t i = 2; i < 5; i++) EXPECT_EQ(vec[i], 100);
 
 
-    // memset doesnt work on every type, but the resize will work
-    PODVector<int, 4> mem_vec;
-    // 5 will be interpreted as 0x05 and transformed to 05|05|05|05 
-    std::memset(mem_vec.data(), 5, 4 * sizeof(4));
+    // memset doesn't work on every type, but it does on the raw POD storage we
+    // own after reserving it (size stays 0, the bytes are ours to write)
+    PODVector<int> mem_vec;
+    mem_vec.reserve(4);
+    // 5 will be interpreted as 0x05 and transformed to 05|05|05|05
+    std::memset(mem_vec.data(), 5, 4 * sizeof(int));
     for(size_t i = 0; i < 4; i++) EXPECT_EQ(mem_vec[i], 84215045);
-    
+
     mem_vec.resize(4, 5);
     for(size_t i = 0; i < 4; i++) EXPECT_EQ(mem_vec[i], 5);
 
 
-    PODVector<Point, 2> point_vec;
+    PODVector<Point> point_vec;
     point_vec.push_back({1, 2});
     point_vec.push_back({3, 4});
     point_vec.push_back({5, 6});   // it should grow
-    ASSERT_EQ(point_vec.size(), 3);
+    ASSERT_EQ(point_vec.size(), 3u);
     EXPECT_EQ(point_vec[0], (Point{1, 2}));
     EXPECT_EQ(point_vec[2], (Point{5, 6}));
 
-    // sizeof podvector<int, 4> is the same as a podvector<point, 2> because both of them have 4 ints
-    EXPECT_EQ(sizeof(PODVector<int, 4>), sizeof(PODVector<Point, 2>));
+    // sizeof is independent of T: every PODVector is just {size, capacity, ptr}
+    EXPECT_EQ(sizeof(PODVector<int>), sizeof(PODVector<Point>));
 }
 
 
 TEST(PODVectorTest, CopyingAndMoving) {
-    // copying as a copy and not pointer in the stack
-    PODVector<int, 4> a = {1, 2, 3};
-    PODVector<int, 4> b = a;
+    // copying makes an independent deep copy
+    PODVector<int> a = {1, 2, 3};
+    PODVector<int> b = a;
     b[0] = 1000;
     EXPECT_EQ(a[0], 1);
     EXPECT_EQ(b[0], 1000);
 
-    // copying as a copy in the heap 
-    PODVector<int, 4> c = {1, 2, 3, 4, 5};
-    PODVector<int, 4> d = c;
+    // copying a larger vector
+    PODVector<int> c = {1, 2, 3, 4, 5};
+    PODVector<int> d = c;
     d[0] = 1000;
     EXPECT_EQ(c[0], 1);
     EXPECT_EQ(d[0], 1000);
 
-    // copying overwrites
-    PODVector<int, 4> e = {1, 2, 3, 4, 5};
-    PODVector<int, 4> f = {0, 0};
+    // copy assignment overwrites
+    PODVector<int> e = {1, 2, 3, 4, 5};
+    PODVector<int> f = {0, 0};
     EXPECT_EQ(f.size(), 2);
     f = e;
     EXPECT_EQ(f.size(), e.size());
     for(size_t i = 0; i < e.size(); i++) EXPECT_EQ(f[i], e[i]);
 
-    // swapping between small vectors
+    // swapping small vectors
     // a = {1, 2, 3}, b = {1000, 2, 3}
     a.swap(b);
     EXPECT_EQ(a[0], 1000);
@@ -128,22 +124,18 @@ TEST(PODVectorTest, CopyingAndMoving) {
     EXPECT_EQ(a.size(), 3);
     EXPECT_EQ(b.size(), 3);
 
-    // swapping between heap vectors
+    // swapping larger vectors
     e[0] = 1000;
     e.push_back(6);
     e.swap(f);
     EXPECT_EQ(f[0], 1000);
     EXPECT_EQ(f[5], 6);
     EXPECT_EQ(e[0], 1);
-    EXPECT_FALSE(e.is_small());
-    EXPECT_FALSE(f.is_small());
 
-    // swapping between heap and stack vectors
+    // swapping vectors of different sizes
     a[0] = 1;
     // a = {1, 2, 3}, f = {1000, 2, 3, 4, 5, 6}
     a.swap(f);
-    EXPECT_TRUE(f.is_small());
-    EXPECT_FALSE(a.is_small());
     EXPECT_EQ(a.size(), 6);
     EXPECT_EQ(f.size(), 3);
     EXPECT_EQ(a[0], 1000);
@@ -152,8 +144,6 @@ TEST(PODVectorTest, CopyingAndMoving) {
 
     // swapping back to check the inverse swap
     f.swap(a);
-    EXPECT_TRUE(a.is_small());
-    EXPECT_FALSE(f.is_small());
     EXPECT_EQ(f.size(), 6);
     EXPECT_EQ(a.size(), 3);
     EXPECT_EQ(f[0], 1000);
@@ -162,23 +152,42 @@ TEST(PODVectorTest, CopyingAndMoving) {
 }
 
 
+TEST(PODVectorTest, MovePreservesPointers) {
+	// as we only work in the heap we can move the data
+	// without losing the pointers information.
+    PODVector<int> src = {10, 20, 30, 40, 50};
+    int* p = &src[2];
+
+    PODVector<int> dst = std::move(src);
+    EXPECT_EQ(*p, 30);
+    EXPECT_EQ(dst[2], 30);
+    EXPECT_EQ(src.size(), 0);
+
+    // move assignment behaves the same
+    PODVector<int> other = {1, 2};
+    other = std::move(dst);
+    EXPECT_EQ(*p, 30);
+    EXPECT_EQ(other.size(), 5);
+    EXPECT_EQ(dst.size(), 0);
+}
+
+
 TEST(PODVectorTest, IteratorsAndRanges) {
-    // Intentar usar un lower_bound, range?, un for auto
-    PODVector<int, 4> sorted_vec = {1, 100, 105, 200, 200, 300};
+    PODVector<int> sorted_vec = {1, 100, 105, 200, 200, 300};
     EXPECT_EQ(*std::lower_bound(sorted_vec.begin(), sorted_vec.end(), 1), 1);
     EXPECT_EQ(*std::upper_bound(sorted_vec.begin(), sorted_vec.end(), 1), 100);
     EXPECT_EQ(*std::lower_bound(sorted_vec.begin(), sorted_vec.end(), 50), 100);
     EXPECT_EQ(*std::lower_bound(sorted_vec.begin(), sorted_vec.end(), 100), 100);
     EXPECT_EQ(*std::lower_bound(sorted_vec.begin(), sorted_vec.end(), 103), 105);
-    
+
     // auto
     std::vector<int> real_vector = {1, 100, 105, 200, 200, 300};
     int ind = 0;
-    for(auto& x : sorted_vec) 
+    for(auto& x : sorted_vec)
         EXPECT_EQ(x, real_vector[ind++]);
-    
 
-    PODVector<int, 4> v{1, 2, 3};
+
+    PODVector<int> v{1, 2, 3};
     EXPECT_EQ((v.end() - v.begin()), v.size());
 
     auto doublepodvec = sorted_vec | std::ranges::views::transform([](int x) { return 2 * x;});
@@ -189,12 +198,12 @@ TEST(PODVectorTest, IteratorsAndRanges) {
 TEST(PODVectorTest, InsertElements) {
     // Inserting at a random position, the begin and the end
     {
-        PODVector<int, 4> v = {1, 2, 4, 5};
+        PODVector<int> v = {1, 2, 4, 5};
         auto it = v.insert(v.begin() + 2, 3);
         EXPECT_EQ(*it, 3);
         EXPECT_EQ(v.size(), 5);
 
-        
+
         auto it_begin = v.insert(v.begin(), 0);
         EXPECT_EQ(*it_begin, 0);
         EXPECT_EQ(v.front(), 0);
@@ -207,23 +216,20 @@ TEST(PODVectorTest, InsertElements) {
         int ind = 0;
         for(auto& x : v) EXPECT_EQ(x, expected[ind++]);
     }
-    
+
     // Checking growth and small condition
     {
-        PODVector<int, 2> v = {1, 3};
-        EXPECT_TRUE(v.is_small());
-
+        PODVector<int> v = {1, 3};
         v.insert(v.begin() + 1, 2);
-        EXPECT_FALSE(v.is_small());
         EXPECT_EQ(v.size(), 3);
         EXPECT_EQ(v[0], 1);
         EXPECT_EQ(v[1], 2);
         EXPECT_EQ(v[2], 3);
     }
-    
+
     // Inserting iterators
     {
-        PODVector<int, 4> v = {1, 2, 6, 7};
+        PODVector<int> v = {1, 2, 6, 7};
         std::vector<int> src = {3, 4, 5};
 
         auto it = v.insert(v.begin() + 2, src.begin(), src.end());
@@ -234,4 +240,3 @@ TEST(PODVectorTest, InsertElements) {
         for(auto& x : v) EXPECT_EQ(x, expected[ind++]);
     }
 }
-

--- a/tests/test_podvector.cpp
+++ b/tests/test_podvector.cpp
@@ -240,3 +240,165 @@ TEST(PODVectorTest, InsertElements) {
         for(auto& x : v) EXPECT_EQ(x, expected[ind++]);
     }
 }
+
+TEST(PODVectorTest, EmplaceBack) {
+    // emplace_back forwards args to T's constructor and returns a reference
+    PODVector<Point> v;
+    Point& ref = v.emplace_back(1, 2);
+    EXPECT_EQ(ref, (Point{1, 2}));
+    ref.x = 10;
+    EXPECT_EQ(v[0], (Point{10, 2}));
+
+    v.emplace_back(3, 4);
+    v.emplace_back(5, 6);
+    EXPECT_EQ(v.size(), 3);
+    EXPECT_EQ(v.back(), (Point{5, 6}));
+
+    // self-reference under growth: emplace_back(v[0]) must not read freed memory
+    PODVector<int> s = {7};
+    for (int i = 0; i < 50; i++) s.emplace_back(s[0]);
+    for (auto x : s) EXPECT_EQ(x, 7);
+}
+
+TEST(PODVectorTest, Erase) {
+    PODVector<int> e = {0, 1, 2, 3, 4, 5};
+
+    // erase(pos) removes one element and returns the iterator to the next
+    auto it = e.erase(e.begin() + 1); // remove 1
+    EXPECT_EQ(*it, 2);
+    EXPECT_EQ(e.size(), 5);
+    {
+	    std::vector<int> exp = {0, 2, 3, 4, 5};
+    	int i = 0;
+    	for(auto x : e) EXPECT_EQ(x, exp[i++]);
+    }
+
+    // erase(first, last) removes a range and returns the iterator past it
+    it = e.erase(e.begin() + 1, e.begin() + 3);   // remove 2, 3
+    EXPECT_EQ(*it, 4);
+    EXPECT_EQ(e.size(), 3);
+    {
+	    std::vector<int> exp = {0, 4, 5};
+    	int i = 0;
+    	for(auto x : e) EXPECT_EQ(x, exp[i++]);
+    }
+
+    // erasing the last element (zero-length tail move)
+    e.erase(e.end() - 1);
+    EXPECT_EQ(e.size(), 2);
+    EXPECT_EQ(e.back(), 4);
+
+    // empty range is a no-op that returns the position
+    it = e.erase(e.begin(), e.begin());
+    EXPECT_EQ(it, e.begin());
+    EXPECT_EQ(e.size(), 2);
+}
+
+TEST(PODVectorTest, Assign) {
+    PODVector<int> a = {1, 2, 3, 4, 5};
+
+    // assign(count, value) replaces the whole content, growing as needed
+    a.assign(3, 7);
+    EXPECT_EQ(a.size(), 3);
+    for (auto x : a) EXPECT_EQ(x, 7);
+
+    a.assign(6, 9);
+    EXPECT_EQ(a.size(), 6);
+    EXPECT_EQ(a.front(), 9);
+    EXPECT_EQ(a.back(), 9);
+
+    a.assign(1, 4);
+    EXPECT_EQ(a.size(), 1);
+    EXPECT_EQ(a[0], 4);
+}
+
+TEST(PODVectorTest, ReverseIteratorsAndFreeSwap) {
+    PODVector<int> v = {1, 2, 3, 4};
+
+    // rbegin/rend walk the vector backwards
+    std::vector<int> rev(v.rbegin(), v.rend());
+    EXPECT_EQ(rev, (std::vector<int>{4, 3, 2, 1}));
+
+    // const reverse iterators and cbegin/cend
+    const PODVector<int>& cv = v;
+    EXPECT_EQ(*cv.crbegin(), 4);
+    EXPECT_EQ(*(cv.crend() - 1), 1);
+    EXPECT_EQ((cv.cend() - cv.cbegin()), v.size());
+
+    // explicit non-member TU::swap(a, b)
+    PODVector<int> a = {1, 2}, b = {9, 8, 7};
+    TU::swap(a, b);
+    EXPECT_EQ(a.size(), 3);
+    EXPECT_EQ(b.size(), 2);
+    EXPECT_EQ(a[0], 9);
+    EXPECT_EQ(b[0], 1);
+}
+
+TEST(PODVectorTest, SelfReferenceUnderGrowth) {
+    // push_back(v[0]) repeatedly forces many reallocations while the argument
+    // aliases an element that grow() is about to move: must not read freed memory
+    {
+        PODVector<int> v = {7};
+        for (int i = 0; i < 50; i++) v.push_back(v[0]);
+        EXPECT_EQ(v.size(), 51);
+        for (auto x : v) EXPECT_EQ(x, 7);
+    }
+
+    // emplace_back(v[0]) has the same hazard
+    {
+        PODVector<int> v = {9};
+        for (int i = 0; i < 50; i++) v.emplace_back(v[0]);
+        for (auto x : v) EXPECT_EQ(x, 9);
+    }
+
+    // insert(pos, v.back()) exactly at capacity, so the insert triggers growth
+    {
+        PODVector<int> v = {1, 2, 3, 4};       // init_list reserves size == capacity
+        ASSERT_EQ(v.size(), v.capacity());
+        v.insert(v.begin(), v.back());
+        std::vector<int> exp = {4, 1, 2, 3, 4};
+        int i = 0; for (auto x : v) EXPECT_EQ(x, exp[i++]);
+    }
+
+    // resize(n, v.back()) growing well past capacity
+    {
+        PODVector<int> v = {5};
+        v.resize(v.capacity() * 8 + 10, v.back());
+        for (auto x : v) EXPECT_EQ(x, 5);
+    }
+
+    // assign(count, v[0]) where the value aliases an element being cleared
+    {
+        PODVector<int> v = {42, 1, 2};
+        v.assign(10, v[0]);
+        EXPECT_EQ(v.size(), 10);
+        for (auto x : v) EXPECT_EQ(x, 42);
+    }
+}
+
+TEST(PODVectorTest, EmptyAndSelfSwap) {
+    // copy / move / swap of empty vectors exercise the null-pointer memcpy paths
+    PODVector<int> empty;
+
+    PODVector<int> copy = empty;              // copy ctor from empty
+    EXPECT_TRUE(copy.empty());
+
+    PODVector<int> assigned = {1, 2, 3};
+    assigned = empty;                          // copy assignment from empty
+    EXPECT_TRUE(assigned.empty());
+
+    PODVector<int> moved = std::move(empty);   // move ctor from empty
+    EXPECT_TRUE(moved.empty());
+
+    PODVector<int> ea, eb;                     // swap of two empties
+    ea.swap(eb);
+    EXPECT_TRUE(ea.empty());
+    EXPECT_TRUE(eb.empty());
+
+    // self-swap must be a no-op, not corruption
+    PODVector<int> s = {1, 2, 3};
+    s.swap(s);
+    EXPECT_EQ(s.size(), 3);
+    EXPECT_EQ(s[0], 1);
+    EXPECT_EQ(s[2], 3);
+}

--- a/tests/test_smallvector.cpp
+++ b/tests/test_smallvector.cpp
@@ -1,0 +1,455 @@
+#include <gtest/gtest.h>
+#include "tubul.h"
+#include <vector>
+#include <string>
+#include <memory>
+#include <ranges>
+
+using TU::SmallVector;
+
+namespace {
+
+struct SVPoint {
+    int x, y;
+    bool operator==(const SVPoint& other) const {
+        return x == other.x and y == other.y;
+    }
+};
+
+// Non-trivially-copyable type that counts alive instances, to catch missing
+// destructor calls, double destructions and leaks.
+struct Tracked {
+    static inline int live = 0;
+    std::string s;
+
+    Tracked() { ++live; }
+    explicit Tracked(std::string v) : s(std::move(v)) { ++live; }
+    Tracked(const Tracked& o) : s(o.s) { ++live; }
+    Tracked(Tracked&& o) noexcept : s(std::move(o.s)) { ++live; }
+    Tracked& operator=(const Tracked&) = default;
+    Tracked& operator=(Tracked&&) noexcept = default;
+    ~Tracked() { --live; }
+    bool operator==(const Tracked& o) const { return s == o.s; }
+};
+static_assert(!std::is_trivially_copyable_v<Tracked>);
+
+// Non-trivially-copyable but safe to relocate with memcpy (it owns memory but
+// holds no pointer into itself).
+struct RelocInt {
+    int* p;
+    RelocInt() : p(new int(0)) {}
+    explicit RelocInt(int v) : p(new int(v)) {}
+    RelocInt(const RelocInt& o) : p(new int(*o.p)) {}
+    RelocInt(RelocInt&& o) noexcept : p(std::exchange(o.p, nullptr)) {}
+    RelocInt& operator=(const RelocInt& o) { *this = RelocInt(o); return *this; }
+    RelocInt& operator=(RelocInt&& o) noexcept { std::swap(p, o.p); return *this; }
+    ~RelocInt() { delete p; }
+};
+static_assert(!std::is_trivially_copyable_v<RelocInt>);
+
+// long enough to defeat the small string optimization, so every element drags
+// a real heap allocation
+std::string bigstr(int i) {
+    return "payload-that-does-not-fit-in-sso-" + std::to_string(i);
+}
+
+} // namespace
+
+template <>
+inline constexpr bool TU::detail::is_relocatable_v<RelocInt> = true;
+
+TEST(SmallVectorTest, testSmallVectorBasics) {
+    // Create an empty vec
+    SmallVector<int, 4> vec;
+    EXPECT_TRUE(vec.empty());
+    EXPECT_EQ(vec.size(), 0);
+    EXPECT_EQ(vec.capacity(), 4);
+    EXPECT_TRUE(vec.is_small());
+
+    // Push elements and confirm the new items, size and capacity
+    for(size_t i = 0; i < 4; i++) vec.push_back(i);
+    for(size_t i = 0; i < 4; i++) EXPECT_EQ(vec[i], i);
+    EXPECT_EQ(vec.size(), 4);
+    EXPECT_TRUE(vec.is_small());
+    EXPECT_EQ(vec.capacity(), 4);
+
+    // Front and back working
+    EXPECT_EQ(vec.front(), 0);
+    EXPECT_EQ(vec.back(), 3);
+
+    // Buffer changes from stack to capacity when the capacity is not enough
+    vec.push_back(4);
+    EXPECT_FALSE(vec.is_small());
+    EXPECT_EQ(vec.size(), 5);
+    EXPECT_EQ(vec.capacity(), 6); // new_capacity = 4 + 4/2 = 6
+
+    // Expect the new capacity with 1.5 factor
+    vec.push_back(5);
+    vec.push_back(6);
+    EXPECT_EQ(vec.size(), 7);
+    EXPECT_EQ(vec.capacity(), 9); // new_capacity = 6 + 6/2 = 9
+
+    // Capacity doesn't change with pop_backs
+    // the vector shouldn't be small because the capacity is still 9
+    for(size_t i = 0; i < 3; i++) vec.pop_back();
+    EXPECT_EQ(vec.size(), 4);
+    EXPECT_FALSE(vec.is_small());
+    EXPECT_EQ(vec.capacity(), 9);
+
+    // The clear is working
+    vec.clear();
+    EXPECT_EQ(vec.size(), 0);
+    EXPECT_TRUE(vec.empty());
+    EXPECT_FALSE(vec.is_small());
+    EXPECT_EQ(vec.capacity(), 9);
+
+    // Pop back with 0 elements does nothing
+    vec.pop_back();
+    EXPECT_TRUE(vec.empty());
+
+    // Out of range with at
+    EXPECT_THROW(vec.at(0), std::out_of_range);
+    EXPECT_THROW(vec.at(1), std::out_of_range);
+
+    // Resize and fill with default value
+    vec = {1, 2, 3, 4, 5, 6, 7};
+    EXPECT_EQ(vec.size(), 7);
+    vec.resize(2);
+    EXPECT_EQ(vec.size(), 2);
+    vec.resize(5, 100);
+    for(size_t i = 2; i < 5; i++) EXPECT_EQ(vec[i], 100);
+
+
+    // memset doesnt work on every type, but the resize will work
+    SmallVector<int, 4> mem_vec;
+    // 5 will be interpreted as 0x05 and transformed to 05|05|05|05
+    std::memset(mem_vec.data(), 5, 4 * sizeof(4));
+    for(size_t i = 0; i < 4; i++) EXPECT_EQ(mem_vec[i], 84215045);
+
+    mem_vec.resize(4, 5);
+    for(size_t i = 0; i < 4; i++) EXPECT_EQ(mem_vec[i], 5);
+
+
+    SmallVector<SVPoint, 2> point_vec;
+    point_vec.push_back({1, 2});
+    point_vec.push_back({3, 4});
+    point_vec.push_back({5, 6});   // it should grow
+    ASSERT_EQ(point_vec.size(), 3);
+    EXPECT_EQ(point_vec[0], (SVPoint{1, 2}));
+    EXPECT_EQ(point_vec[2], (SVPoint{5, 6}));
+
+    // sizeof SmallVector<int, 4> is the same as a SmallVector<SVPoint, 2> because both of them have 4 ints
+    EXPECT_EQ(sizeof(SmallVector<int, 4>), sizeof(SmallVector<SVPoint, 2>));
+}
+
+
+TEST(SmallVectorTest, CopyingAndMoving) {
+    // copying as a copy and not pointer in the stack
+    SmallVector<int, 4> a = {1, 2, 3};
+    SmallVector<int, 4> b = a;
+    b[0] = 1000;
+    EXPECT_EQ(a[0], 1);
+    EXPECT_EQ(b[0], 1000);
+
+    // copying as a copy in the heap
+    SmallVector<int, 4> c = {1, 2, 3, 4, 5};
+    SmallVector<int, 4> d = c;
+    d[0] = 1000;
+    EXPECT_EQ(c[0], 1);
+    EXPECT_EQ(d[0], 1000);
+
+    // copying overwrites
+    SmallVector<int, 4> e = {1, 2, 3, 4, 5};
+    SmallVector<int, 4> f = {0, 0};
+    EXPECT_EQ(f.size(), 2);
+    f = e;
+    EXPECT_EQ(f.size(), e.size());
+    for(size_t i = 0; i < e.size(); i++) EXPECT_EQ(f[i], e[i]);
+
+    // swapping between small vectors
+    // a = {1, 2, 3}, b = {1000, 2, 3}
+    a.swap(b);
+    EXPECT_EQ(a[0], 1000);
+    EXPECT_EQ(b[0], 1);
+    EXPECT_EQ(a.size(), 3);
+    EXPECT_EQ(b.size(), 3);
+
+    // swapping between heap vectors
+    e[0] = 1000;
+    e.push_back(6);
+    e.swap(f);
+    EXPECT_EQ(f[0], 1000);
+    EXPECT_EQ(f[5], 6);
+    EXPECT_EQ(e[0], 1);
+    EXPECT_FALSE(e.is_small());
+    EXPECT_FALSE(f.is_small());
+
+    // swapping between heap and stack vectors
+    a[0] = 1;
+    // a = {1, 2, 3}, f = {1000, 2, 3, 4, 5, 6}
+    a.swap(f);
+    EXPECT_TRUE(f.is_small());
+    EXPECT_FALSE(a.is_small());
+    EXPECT_EQ(a.size(), 6);
+    EXPECT_EQ(f.size(), 3);
+    EXPECT_EQ(a[0], 1000);
+    EXPECT_EQ(a[5], 6);
+    EXPECT_EQ(f[0], 1);
+
+    // swapping back to check the inverse swap
+    f.swap(a);
+    EXPECT_TRUE(a.is_small());
+    EXPECT_FALSE(f.is_small());
+    EXPECT_EQ(f.size(), 6);
+    EXPECT_EQ(a.size(), 3);
+    EXPECT_EQ(f[0], 1000);
+    EXPECT_EQ(f[5], 6);
+    EXPECT_EQ(a[0], 1);
+}
+
+
+TEST(SmallVectorTest, IteratorsAndRanges) {
+    SmallVector<int, 4> sorted_vec = {1, 100, 105, 200, 200, 300};
+    EXPECT_EQ(*std::lower_bound(sorted_vec.begin(), sorted_vec.end(), 1), 1);
+    EXPECT_EQ(*std::upper_bound(sorted_vec.begin(), sorted_vec.end(), 1), 100);
+    EXPECT_EQ(*std::lower_bound(sorted_vec.begin(), sorted_vec.end(), 50), 100);
+    EXPECT_EQ(*std::lower_bound(sorted_vec.begin(), sorted_vec.end(), 100), 100);
+    EXPECT_EQ(*std::lower_bound(sorted_vec.begin(), sorted_vec.end(), 103), 105);
+
+    // auto
+    std::vector<int> real_vector = {1, 100, 105, 200, 200, 300};
+    int ind = 0;
+    for(auto& x : sorted_vec)
+        EXPECT_EQ(x, real_vector[ind++]);
+
+
+    SmallVector<int, 4> v{1, 2, 3};
+    EXPECT_EQ((v.end() - v.begin()), v.size());
+
+    auto doublevec = sorted_vec | std::ranges::views::transform([](int x) { return 2 * x;});
+    ind = 0;
+    for(auto x: doublevec) EXPECT_EQ(2 * real_vector[ind++], x);
+}
+
+TEST(SmallVectorTest, InsertElements) {
+    // Inserting at a random position, the begin and the end
+    {
+        SmallVector<int, 4> v = {1, 2, 4, 5};
+        auto it = v.insert(v.begin() + 2, 3);
+        EXPECT_EQ(*it, 3);
+        EXPECT_EQ(v.size(), 5);
+
+
+        auto it_begin = v.insert(v.begin(), 0);
+        EXPECT_EQ(*it_begin, 0);
+        EXPECT_EQ(v.front(), 0);
+
+        auto it_end = v.insert(v.end(), 6);
+        EXPECT_EQ(*it_end, 6);
+        EXPECT_EQ(v.back(), 6);
+
+        std::vector<int> expected = {0, 1, 2, 3, 4, 5, 6};
+        int ind = 0;
+        for(auto& x : v) EXPECT_EQ(x, expected[ind++]);
+    }
+
+    // Checking growth and small condition
+    {
+        SmallVector<int, 2> v = {1, 3};
+        EXPECT_TRUE(v.is_small());
+
+        v.insert(v.begin() + 1, 2);
+        EXPECT_FALSE(v.is_small());
+        EXPECT_EQ(v.size(), 3);
+        EXPECT_EQ(v[0], 1);
+        EXPECT_EQ(v[1], 2);
+        EXPECT_EQ(v[2], 3);
+    }
+
+    // Inserting iterators
+    {
+        SmallVector<int, 4> v = {1, 2, 6, 7};
+        std::vector<int> src = {3, 4, 5};
+
+        auto it = v.insert(v.begin() + 2, src.begin(), src.end());
+        EXPECT_EQ(*it, 3);
+        EXPECT_EQ(v.size(), 7);
+        std::vector<int> expected = {1, 2, 3, 4, 5, 6, 7};
+        int ind = 0;
+        for(auto& x : v) EXPECT_EQ(x, expected[ind++]);
+    }
+}
+
+// Non-trivially_copyable
+
+TEST(SmallVectorTest, NonPodBasics) {
+    SmallVector<std::string, 4> vec;
+    EXPECT_TRUE(vec.is_small());
+
+    for (int i = 0; i < 10; i++) vec.push_back(bigstr(i));
+    EXPECT_FALSE(vec.is_small());
+    EXPECT_EQ(vec.size(), 10);
+    for (int i = 0; i < 10; i++) EXPECT_EQ(vec[i], bigstr(i));
+
+    // resize down destroys, resize up fills
+    vec.resize(3);
+    EXPECT_EQ(vec.size(), 3);
+    vec.resize(6, bigstr(999));
+    for (size_t i = 3; i < 6; i++) EXPECT_EQ(vec[i], bigstr(999));
+
+    // insert in the middle, at begin and at end, growing from small
+    SmallVector<std::string, 2> v = {bigstr(1), bigstr(3)};
+    v.insert(v.begin() + 1, bigstr(2));
+    v.insert(v.begin(), bigstr(0));
+    v.insert(v.end(), bigstr(4));
+    ASSERT_EQ(v.size(), 5);
+    for (int i = 0; i < 5; i++) EXPECT_EQ(v[i], bigstr(i));
+
+    // range insert in the middle without growing past it
+    std::vector<std::string> src = {bigstr(10), bigstr(11)};
+    v.insert(v.begin() + 2, src.begin(), src.end());
+    ASSERT_EQ(v.size(), 7);
+    EXPECT_EQ(v[1], bigstr(1));
+    EXPECT_EQ(v[2], bigstr(10));
+    EXPECT_EQ(v[3], bigstr(11));
+    EXPECT_EQ(v[4], bigstr(2));
+
+    // count insert
+    v.insert(v.begin(), 3, bigstr(777));
+    ASSERT_EQ(v.size(), 10);
+    for (int i = 0; i < 3; i++) EXPECT_EQ(v[i], bigstr(777));
+    EXPECT_EQ(v[3], bigstr(0));
+}
+
+TEST(SmallVectorTest, NonPodLifetimes) {
+    Tracked::live = 0;
+    {
+        SmallVector<Tracked, 2> vec;
+        for (int i = 0; i < 8; i++) vec.push_back(Tracked(bigstr(i)));
+        EXPECT_EQ(Tracked::live, 8);
+
+        vec.pop_back();
+        EXPECT_EQ(Tracked::live, 7);
+
+        vec.resize(3);
+        EXPECT_EQ(Tracked::live, 3);
+
+        vec.resize(5, Tracked(bigstr(50)));
+        EXPECT_EQ(Tracked::live, 5);
+
+        vec.insert(vec.begin() + 1, 2, Tracked(bigstr(60)));
+        EXPECT_EQ(Tracked::live, 7);
+        EXPECT_EQ(vec[0].s, bigstr(0));
+        EXPECT_EQ(vec[1].s, bigstr(60));
+        EXPECT_EQ(vec[2].s, bigstr(60));
+        EXPECT_EQ(vec[3].s, bigstr(1));
+
+        vec.clear();
+        EXPECT_EQ(Tracked::live, 0);
+        EXPECT_FALSE(vec.is_small());
+    }
+    EXPECT_EQ(Tracked::live, 0);
+
+    // copies duplicate lifetimes, moves transfer them
+    {
+        SmallVector<Tracked, 2> a;
+        for (int i = 0; i < 5; i++) a.push_back(Tracked(bigstr(i)));
+        EXPECT_EQ(Tracked::live, 5);
+
+        SmallVector<Tracked, 2> b = a;
+        EXPECT_EQ(Tracked::live, 10);
+        EXPECT_EQ(b[4].s, bigstr(4));
+
+        SmallVector<Tracked, 2> c = std::move(a);
+        EXPECT_EQ(Tracked::live, 10);
+        EXPECT_EQ(c.size(), 5);
+        EXPECT_EQ(a.size(), 0);
+
+        b = std::move(c);
+        EXPECT_EQ(Tracked::live, 5);
+        EXPECT_EQ(b.size(), 5);
+        EXPECT_EQ(b[4].s, bigstr(4));
+
+        // copy assignment overwrites previous contents
+        SmallVector<Tracked, 2> d;
+        d.push_back(Tracked(bigstr(100)));
+        d = b;
+        EXPECT_EQ(Tracked::live, 10);
+        EXPECT_EQ(d.size(), 5);
+    }
+    EXPECT_EQ(Tracked::live, 0);
+
+    // swaps in every storage combination
+    {
+        SmallVector<Tracked, 4> small1 = {Tracked(bigstr(1))};
+        SmallVector<Tracked, 4> small2 = {Tracked(bigstr(2)), Tracked(bigstr(3))};
+        small1.swap(small2);
+        EXPECT_EQ(small1.size(), 2);
+        EXPECT_EQ(small2.size(), 1);
+        EXPECT_EQ(small1[0].s, bigstr(2));
+        EXPECT_EQ(small2[0].s, bigstr(1));
+
+        SmallVector<Tracked, 2> heap1;
+        for (int i = 0; i < 5; i++) heap1.push_back(Tracked(bigstr(i)));
+        SmallVector<Tracked, 2> heap2;
+        for (int i = 10; i < 14; i++) heap2.push_back(Tracked(bigstr(i)));
+        heap1.swap(heap2);
+        EXPECT_EQ(heap1.size(), 4);
+        EXPECT_EQ(heap2.size(), 5);
+        EXPECT_EQ(heap1[0].s, bigstr(10));
+        EXPECT_EQ(heap2[0].s, bigstr(0));
+
+        SmallVector<Tracked, 2> mixed_small = {Tracked(bigstr(1))};
+        mixed_small.swap(heap1);
+        EXPECT_EQ(mixed_small.size(), 4);
+        EXPECT_FALSE(mixed_small.is_small());
+        EXPECT_EQ(heap1.size(), 1);
+        EXPECT_TRUE(heap1.is_small());
+        EXPECT_EQ(heap1[0].s, bigstr(1));
+        EXPECT_EQ(mixed_small[0].s, bigstr(10));
+    }
+    EXPECT_EQ(Tracked::live, 0);
+}
+
+TEST(SmallVectorTest, MoveOnlyTypes) {
+    SmallVector<std::unique_ptr<int>, 2> vec;
+    for (int i = 0; i < 6; i++) vec.push_back(std::make_unique<int>(i));
+    ASSERT_EQ(vec.size(), 6);
+    for (int i = 0; i < 6; i++) EXPECT_EQ(*vec[i], i);
+
+    vec.insert(vec.begin() + 3, std::make_unique<int>(100));
+    ASSERT_EQ(vec.size(), 7);
+    EXPECT_EQ(*vec[2], 2);
+    EXPECT_EQ(*vec[3], 100);
+    EXPECT_EQ(*vec[4], 3);
+
+    vec.pop_back();
+    EXPECT_EQ(vec.size(), 6);
+
+    SmallVector<std::unique_ptr<int>, 2> moved = std::move(vec);
+    EXPECT_EQ(moved.size(), 6);
+    EXPECT_EQ(vec.size(), 0);
+    EXPECT_EQ(*moved[3], 100);
+
+    moved.clear();
+    EXPECT_TRUE(moved.empty());
+}
+
+TEST(SmallVectorTest, RelocatableOptIn) {
+    static_assert(TU::detail::is_relocatable_v<RelocInt>);
+
+    // growth for an opt-in relocatable type goes through the realloc/memcpy
+    // path: a double delete or a lost element would blow up here
+    SmallVector<RelocInt, 2> vec;
+    for (int i = 0; i < 20; i++) vec.push_back(RelocInt(i));
+    ASSERT_EQ(vec.size(), 20);
+    for (int i = 0; i < 20; i++) EXPECT_EQ(*vec[i].p, i);
+
+    vec.insert(vec.begin() + 5, RelocInt(500));
+    EXPECT_EQ(*vec[5].p, 500);
+    EXPECT_EQ(*vec[6].p, 5);
+
+    vec.resize(4);
+    EXPECT_EQ(vec.size(), 4);
+    EXPECT_EQ(*vec[3].p, 3);
+}

--- a/tests/test_smallvector.cpp
+++ b/tests/test_smallvector.cpp
@@ -453,3 +453,186 @@ TEST(SmallVectorTest, RelocatableOptIn) {
     EXPECT_EQ(vec.size(), 4);
     EXPECT_EQ(*vec[3].p, 3);
 }
+
+TEST(SmallVectorTest, EmplaceBack) {
+    // emplace_back forwards args and returns a reference, small and after growth
+    SmallVector<SVPoint, 2> p;
+    SVPoint& ref = p.emplace_back(1, 2); // parenthesized aggregate init (C++20)
+    EXPECT_EQ(ref, (SVPoint{1, 2}));
+    p.emplace_back(3, 4);
+    p.emplace_back(5, 6); // grows to heap
+    EXPECT_FALSE(p.is_small());
+    EXPECT_EQ(p.size(), 3);
+    EXPECT_EQ(p.back(), (SVPoint{5, 6}));
+
+    // non-trivial element type
+    SmallVector<std::string, 2> s;
+    std::string& sref = s.emplace_back(bigstr(0));
+    EXPECT_EQ(sref, bigstr(0));
+    for(int i = 1; i < 6; i++) s.emplace_back(bigstr(i));   // forces growth
+    EXPECT_EQ(s.size(), 6);
+    for(int i = 0; i < 6; i++) EXPECT_EQ(s[i], bigstr(i));
+}
+
+TEST(SmallVectorTest, EraseAssignReverseSwap) {
+    // erase on a trivially copyable type (memmove path), living on the heap
+    SmallVector<int, 4> e = {0, 1, 2, 3, 4, 5};
+    auto it = e.erase(e.begin() + 1);  // remove 1
+    EXPECT_EQ(*it, 2);
+    {
+	    std::vector<int> exp = {0, 2, 3, 4, 5};
+    	int i = 0;
+    	for(auto x : e) EXPECT_EQ(x, exp[i++]);
+    }
+    it = e.erase(e.begin() + 1, e.begin() + 3);   // remove 2, 3
+    EXPECT_EQ(*it, 4);
+    {
+	    std::vector<int> exp = {0, 4, 5};
+    	int i = 0;
+    	for(auto x : e) EXPECT_EQ(x, exp[i++]);
+    }
+    e.erase(e.end() - 1);
+    EXPECT_EQ(e.size(), 2);
+    EXPECT_EQ(e.back(), 4);
+
+    // assign(count, value), growing past the inline buffer and shrinking back
+    SmallVector<int, 4> a;
+    a.assign(5, 7);
+    EXPECT_EQ(a.size(), 5);
+    EXPECT_FALSE(a.is_small());
+    for(auto x : a) EXPECT_EQ(x, 7);
+    a.assign(2, 3);
+    EXPECT_EQ(a.size(), 2);
+    EXPECT_EQ(a[0], 3);
+    EXPECT_EQ(a[1], 3);
+
+    // reverse iterators and cbegin/cend
+    SmallVector<int, 4> v = {1, 2, 3, 4};
+    std::vector<int> rev(v.rbegin(), v.rend());
+    EXPECT_EQ(rev, (std::vector<int>{4, 3, 2, 1}));
+    const SmallVector<int, 4>& cv = v;
+    EXPECT_EQ(*cv.crbegin(), 4);
+    EXPECT_EQ((cv.cend() - cv.cbegin()), v.size());
+
+    // explicit non-member TU::swap(a, b)
+    SmallVector<int, 4> x = {1, 2}, y = {9, 8, 7};
+    TU::swap(x, y);
+    EXPECT_EQ(x.size(), 3);
+    EXPECT_EQ(y.size(), 2);
+    EXPECT_EQ(x[0], 9);
+    EXPECT_EQ(y[0], 1);
+}
+
+TEST(SmallVectorTest, EraseAssignLifetimes) {
+    // erase/assign must destroy exactly the right elements for non-trivial types
+    Tracked::live = 0;
+    {
+        SmallVector<Tracked, 2> v;
+        for(int i = 0; i < 6; i++) v.emplace_back(bigstr(i));   // heap, live 6
+        EXPECT_EQ(Tracked::live, 6);
+
+        // erase(pos): moves the tail down and destroys one element
+        auto it = v.erase(v.begin() + 1);      // remove element 1
+        EXPECT_EQ(Tracked::live, 5);
+        EXPECT_EQ(it->s, bigstr(2));
+        EXPECT_EQ(v[0].s, bigstr(0));
+        EXPECT_EQ(v[1].s, bigstr(2));
+
+        // erase(first, last): destroys two elements
+        v.erase(v.begin() + 1, v.begin() + 3); // remove 2, 3
+        EXPECT_EQ(Tracked::live, 3);
+        EXPECT_EQ(v[1].s, bigstr(4));
+
+        // assign replaces all previous content (old ones destroyed)
+        v.assign(2, Tracked(bigstr(99)));
+        EXPECT_EQ(Tracked::live, 2);
+        EXPECT_EQ(v[0].s, bigstr(99));
+        EXPECT_EQ(v[1].s, bigstr(99));
+    }
+    EXPECT_EQ(Tracked::live, 0);
+}
+
+TEST(SmallVectorTest, SelfReferenceUnderGrowth) {
+    // trivially copyable: push_back/emplace_back/insert/resize/assign where the
+    // argument aliases an element the container may relocate during growth
+    {
+        SmallVector<int, 2> v = {7};
+        for (int i = 0; i < 50; i++) v.push_back(v[0]);   // crosses inline -> heap
+        EXPECT_FALSE(v.is_small());
+        for (auto x : v) EXPECT_EQ(x, 7);
+    }
+    {
+        SmallVector<int, 2> v = {9};
+        for (int i = 0; i < 50; i++) v.emplace_back(v[0]);
+        for (auto x : v) EXPECT_EQ(x, 9);
+    }
+    {
+        SmallVector<int, 4> v = {1, 2, 3, 4};    // small and exactly full
+        v.insert(v.begin(), v.back());            // triggers growth to heap
+        std::vector<int> exp = {4, 1, 2, 3, 4};
+        int i = 0; for (auto x : v) EXPECT_EQ(x, exp[i++]);
+    }
+    {
+        SmallVector<int, 2> v = {5};
+        v.resize(100, v.back());
+        for (auto x : v) EXPECT_EQ(x, 5);
+    }
+    {
+        SmallVector<int, 2> v = {42, 1, 2};
+        v.assign(10, v[0]);
+        EXPECT_EQ(v.size(), 10);
+        for (auto x : v) EXPECT_EQ(x, 42);
+    }
+
+    // non-trivial: emplace_back(v[0]) and assign(n, v[0]) must not use-after-free
+    // (this is the heap-use-after-free the assign fix closed)
+    Tracked::live = 0;
+    {
+        SmallVector<Tracked, 2> v;
+        v.emplace_back(bigstr(0));
+        for (int i = 0; i < 20; i++) v.emplace_back(v[0]);   // self-ref across growth
+        EXPECT_EQ(v.size(), 21);
+        for (const auto& t : v) EXPECT_EQ(t.s, bigstr(0));
+
+        v.assign(5, v[0]);                                    // self-ref in assign
+        EXPECT_EQ(v.size(), 5);
+        for (const auto& t : v) EXPECT_EQ(t.s, bigstr(0));
+    }
+    EXPECT_EQ(Tracked::live, 0);
+}
+
+TEST(SmallVectorTest, EmptyAndSelfSwap) {
+    // copy / move / swap of empty vectors
+    SmallVector<int, 4> empty;
+
+    SmallVector<int, 4> copy = empty;
+    EXPECT_TRUE(copy.empty());
+
+    SmallVector<int, 4> assigned = {1, 2, 3};
+    assigned = empty;
+    EXPECT_TRUE(assigned.empty());
+
+    SmallVector<int, 4> moved = std::move(empty);
+    EXPECT_TRUE(moved.empty());
+
+    SmallVector<int, 4> ea, eb;
+    ea.swap(eb);
+    EXPECT_TRUE(ea.empty());
+    EXPECT_TRUE(eb.empty());
+
+    // self-swap must be a no-op on inline storage (guards the fix in swap)
+    SmallVector<int, 4> s = {1, 2, 3};
+    EXPECT_TRUE(s.is_small());
+    s.swap(s);
+    EXPECT_EQ(s.size(), 3);
+    EXPECT_EQ(s[0], 1);
+    EXPECT_EQ(s[2], 3);
+
+    // and on heap storage
+    SmallVector<int, 2> h = {1, 2, 3, 4, 5};
+    EXPECT_FALSE(h.is_small());
+    h.swap(h);
+    EXPECT_EQ(h.size(), 5);
+    EXPECT_EQ(h[0], 1);
+    EXPECT_EQ(h[4], 5);
+}

--- a/tubul/tubul_defs.h
+++ b/tubul/tubul_defs.h
@@ -37,3 +37,4 @@
 #include "tubul_enumerate.h"
 #include "tubul_mem_utils.h"
 #include "tubul_podvector.h"
+#include "tubul_smallvector.h"

--- a/tubul/tubul_podvector.h
+++ b/tubul/tubul_podvector.h
@@ -7,6 +7,8 @@
 #pragma once
 
 #include <cstdlib>              // malloc, realloc, free, size_t
+#include <cstddef>              // std::max_align_t
+#include <cstdint>              // SIZE_MAX
 #include <type_traits>          // is_trivially_copyable
 #include <initializer_list>     // 
 #include <cstring>              // memcpy
@@ -20,8 +22,12 @@
 namespace TU {
 template <typename T>
 struct PODVector{
-    static_assert(std::is_trivially_copyable<T>::value, 
+    static_assert(std::is_trivially_copyable<T>::value,
         "PODVector<T> requires T to be trivially copyable type."
+    );
+    // malloc/realloc only guarantee max_align_t alignment; over-aligned T would not work.
+    static_assert(alignof(T) <= alignof(std::max_align_t),
+        "PODVector<T> requires alignof(T) <= alignof(std::max_align_t)."
     );
 
 public:
@@ -31,6 +37,8 @@ public:
     using const_reference = const T&;
     using iterator = T*;
     using const_iterator = const T*;
+    using reverse_iterator = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
     // Commons
     bool empty() const { return size_ == 0; }
@@ -54,7 +62,8 @@ public:
     // Copy
     PODVector(const PODVector& other) : PODVector() {
         reserve(other.size_);
-        std::memcpy(data(), other.data(), other.size_ * sizeof(T));
+    	// check if other is not an empty pointer
+        if (other.size_) std::memcpy(data(), other.data(), other.size_ * sizeof(T));
         size_ = other.size_;
     }
 
@@ -65,14 +74,15 @@ public:
     PODVector& operator=(const PODVector& other) {
         if (this == &other) return *this;
         reserve(other.size_);
-        std::memcpy(data(), other.data(), other.size_ * sizeof(T));
+    	// check if other is not an empty pointer
+        if (other.size_) std::memcpy(data(), other.data(), other.size_ * sizeof(T));
         size_ = other.size_;
         return *this;
     }
 
     PODVector(std::initializer_list<T> init) : PODVector() {
         reserve(init.size());
-        std::memcpy(data(), init.begin(), init.size() * sizeof(T));
+        if (init.size()) std::memcpy(data(), init.begin(), init.size() * sizeof(T));
         size_ = init.size();
     }
 
@@ -115,7 +125,17 @@ public:
     const_iterator begin() const { return data(); }
     iterator end() { return data() + size_; }
     const_iterator end() const { return data() + size_; }
-    
+
+    const_iterator cbegin() const { return begin(); }
+    const_iterator cend() const { return end(); }
+
+    reverse_iterator rbegin() { return reverse_iterator(end()); }
+    const_reverse_iterator rbegin() const { return const_reverse_iterator(end()); }
+    reverse_iterator rend() { return reverse_iterator(begin()); }
+    const_reverse_iterator rend() const { return const_reverse_iterator(begin()); }
+    const_reverse_iterator crbegin() const { return const_reverse_iterator(end()); }
+    const_reverse_iterator crend() const { return const_reverse_iterator(begin()); }
+
 
     // Modifiers
     void clear() {
@@ -128,15 +148,27 @@ public:
         data()[size_++] = tmp;
     }
 
+    template <typename... Args>
+    reference emplace_back(Args&&... args) {
+        // build the value before growing: args may reference existing elements
+        T tmp(std::forward<Args>(args)...);
+        if (size_ == capacity_) grow(next_capacity(capacity_ + 1));
+        T* slot = data() + size_;
+        *slot = tmp;
+        ++size_;
+        return *slot;
+    }
+
     void pop_back() noexcept {
         if(size_ > 0) --size_;
     }
 
     void resize(size_type new_size, const T& fill_value = T()) {
+    	T tmp = fill_value;
         if (new_size > capacity_) grow(next_capacity(new_size));
         if (new_size > size_) {
             size_t count = new_size - size_;
-            std::fill_n(data() + size_, count, fill_value);
+            std::fill_n(data() + size_, count, tmp);
         }
         size_ = new_size;
     }
@@ -210,6 +242,28 @@ public:
         return insert(pos, ilist.begin(), ilist.end());
     }
 
+    iterator erase(const_iterator pos) {
+        return erase(pos, pos + 1);
+    }
+
+    iterator erase(const_iterator first, const_iterator last) {
+        size_type index = static_cast<size_type>(first - begin());
+        size_type count = static_cast<size_type>(last - first);
+        if (count == 0) return begin() + index;
+
+        T* p = data();
+        // shift the tail [last, end) down onto the erased range
+        std::memmove(p + index, p + index + count, (size_ - index - count) * sizeof(T));
+        size_ -= count;
+        return p + index;
+    }
+
+    void assign(size_type count, const T& value) {
+        T tmp = value;   // copy before clear: value may alias an element of *this
+        clear();
+        resize(count, tmp);
+    }
+
 
 private:
     size_t size_;
@@ -222,6 +276,7 @@ private:
     }
 
     void grow(size_type new_cap) {
+        if (new_cap > SIZE_MAX / sizeof(T)) throw std::length_error("PODVector: capacity exceeds maximum size");
         T* new_data = static_cast<T*>(std::realloc(ptr_, new_cap * sizeof(T)));
         if (!new_data) throw std::bad_alloc();
         // Change the pointer
@@ -240,5 +295,10 @@ private:
         other.capacity_ = 0;
     }
 };
+
+template <typename T>
+void swap(PODVector<T>& a, PODVector<T>& b) noexcept {
+    a.swap(b);
+}
 
 } // namespace TU

--- a/tubul/tubul_podvector.h
+++ b/tubul/tubul_podvector.h
@@ -184,7 +184,7 @@ public:
     }
 
     template <typename InputIt>
-	requires std::input_iterator<InputIt>
+	requires std::forward_iterator<InputIt>
     iterator insert(const_iterator pos, InputIt first, InputIt last) {
         size_type index = static_cast<size_type>(pos - begin());
         size_type count  = static_cast<size_type>(std::distance(first, last));

--- a/tubul/tubul_podvector.h
+++ b/tubul/tubul_podvector.h
@@ -14,17 +14,14 @@
 #include <utility>              // std::swap
 #include <algorithm>            // fill_n
 #include <new>                  // std::bad_alloc
-#include <iterator>             // std::distance 
+#include <iterator>             // std::distance
 
 
 namespace TU {
-template <typename T, std::size_t N>
+template <typename T>
 struct PODVector{
     static_assert(std::is_trivially_copyable<T>::value, 
-        "PODVector<T, N> requires T to be trivially copyable type."
-    );
-    static_assert(N > 0, 
-        "N must be greater than 0."
+        "PODVector<T> requires T to be trivially copyable type."
     );
 
 public:
@@ -36,12 +33,8 @@ public:
     using const_iterator = const T*;
 
     // Commons
-    bool is_small() const {
-        return capacity_ <= N;
-    }
-
     bool empty() const { return size_ == 0; }
-    
+
     size_type size() const { return size_; }
     
     size_type capacity() const { return capacity_; }
@@ -52,7 +45,7 @@ public:
     }
 
     // Construction
-    PODVector() : size_(0), capacity_(N) {}
+    PODVector() : size_(0), capacity_(0), ptr_(nullptr) {}
 
     explicit PODVector(size_type count, const T& value = T()) : PODVector() {
         resize(count, value);
@@ -85,24 +78,20 @@ public:
 
     PODVector& operator=(PODVector&& other) noexcept {
         if (this == &other) return *this;
-        free_heap();
+    	std::free(ptr_);
         move_from(other);
         return *this;
     }
 
     // Destruction
     ~PODVector() { 
-        free_heap(); 
+    	std::free(ptr_);
     }
 
 
     // Element access
-    T* data() {
-        return is_small()? stackbuf_ : heapbuf_.ptr;
-    }
-    const T* data() const {
-        return is_small()? stackbuf_ : heapbuf_.ptr;
-    }
+    T* data() { return ptr_; }
+    const T* data() const { return ptr_; }
 
     reference operator[](size_type i) { return data()[i]; }
     const_reference operator[](size_type i) const { return data()[i]; }
@@ -136,7 +125,7 @@ public:
     void push_back(const T& value) {
         T tmp = value;
         if (size_ == capacity_) grow(next_capacity(capacity_ + 1));
-        data()[size_++] = tmp;   
+        data()[size_++] = tmp;
     }
 
     void pop_back() noexcept {
@@ -146,29 +135,16 @@ public:
     void resize(size_type new_size, const T& fill_value = T()) {
         if (new_size > capacity_) grow(next_capacity(new_size));
         if (new_size > size_) {
-            T* p = data();
             size_t count = new_size - size_;
-            std::fill_n(p + size_, count, fill_value);
+            std::fill_n(data() + size_, count, fill_value);
         }
         size_ = new_size;
     }
 
     void swap(PODVector& other) noexcept {
-        if (is_small() && other.is_small()) {
-            T tmp_buf[N];
-            std::memcpy(tmp_buf, stackbuf_, size_ * sizeof(T));
-            std::memcpy(stackbuf_, other.stackbuf_, other.size_ * sizeof(T));
-            std::memcpy(other.stackbuf_, tmp_buf, size_ * sizeof(T));
-            std::swap(size_, other.size_);
-        } else if (!is_small() && !other.is_small()) {
-            std::swap(heapbuf_.ptr, other.heapbuf_.ptr);
-            std::swap(size_, other.size_);
-            std::swap(capacity_, other.capacity_);
-        } else {
-            PODVector tmp(std::move(*this));
-            *this = std::move(other);
-            other = std::move(tmp);
-        }
+        std::swap(ptr_, other.ptr_);
+        std::swap(size_, other.size_);
+        std::swap(capacity_, other.capacity_);
     }
 
     iterator insert(const_iterator pos, const T& value) {
@@ -212,9 +188,9 @@ public:
     iterator insert(const_iterator pos, InputIt first, InputIt last) {
         size_type index = static_cast<size_type>(pos - begin());
         size_type count  = static_cast<size_type>(std::distance(first, last));
-        
+
         if (index > size_) throw std::out_of_range("PODVector::insert: pos out of range");
-        
+
         if (count == 0) return begin() + index;
 
         if (size_ + count > capacity_) grow(size_ + count);
@@ -238,12 +214,7 @@ public:
 private:
     size_t size_;
     size_t capacity_;
-    union {
-        struct {
-            T *ptr;
-        } heapbuf_;
-        T stackbuf_[N];
-    };
+	T* ptr_;
 
     size_type next_capacity(size_type min_required) const {
         size_type grown = capacity_ + capacity_ / 2;
@@ -251,40 +222,22 @@ private:
     }
 
     void grow(size_type new_cap) {
-        if (is_small()) {
-            T* new_data = static_cast<T*>(std::malloc(new_cap * sizeof(T)));
-            if (!new_data) throw std::bad_alloc();
-            // Reallocate the memory to the heapbuffer from the stackbuffer
-            std::memcpy(new_data, stackbuf_, size_ * sizeof(T));
-            heapbuf_.ptr = new_data;
-        }
-        else {
-            T* new_data = static_cast<T*>(std::realloc(heapbuf_.ptr, new_cap * sizeof(T)));
-            if (!new_data) throw std::bad_alloc();
-            // Change the pointer
-            heapbuf_.ptr = new_data;
-        }
+        T* new_data = static_cast<T*>(std::realloc(ptr_, new_cap * sizeof(T)));
+        if (!new_data) throw std::bad_alloc();
+        // Change the pointer
+        ptr_ = new_data;
         capacity_ = new_cap;
     }
 
-    void free_heap() {
-        if (!is_small()) std::free(heapbuf_.ptr);
-    }
-
     void move_from(PODVector& other) noexcept {
-        if (other.is_small()) {
-            std::memcpy(stackbuf_, other.stackbuf_, other.size_ * sizeof(T));
-            capacity_ = N;
-        }
-        else {
-            heapbuf_.ptr = other.heapbuf_.ptr;
-            capacity_ = other.capacity_;
-        }
+        ptr_ = other.ptr_;
+        capacity_ = other.capacity_;
         size_ = other.size_;
 
-        // other vector as a small vector
+        // leave the other vector empty. don't free because the memory is now on this ptr.
+        other.ptr_ = nullptr;
         other.size_ = 0;
-        other.capacity_ = N;
+        other.capacity_ = 0;
     }
 };
 

--- a/tubul/tubul_smallvector.h
+++ b/tubul/tubul_smallvector.h
@@ -1,0 +1,465 @@
+//
+// Created by Alicanto Nano on 13-07-26.
+//
+
+#ifndef TUBUL_TUBUL_SMALLVECTOR_H
+#define TUBUL_TUBUL_SMALLVECTOR_H
+
+#endif // TUBUL_TUBUL_SMALLVECTOR_H
+
+#pragma once
+
+// Reference:
+//   folly/container/small_vector.h
+//	   https://github.com/facebook/folly/blob/main/folly/container/small_vector.h#L1444
+//   folly/container/FBVector.h
+//     https://github.com/facebook/folly/blob/main/folly/container/FBVector.h
+//   llvm/include/llvm/ADT/SmallVector.h
+//     https://github.com/llvm/llvm-project/blob/main/llvm/include/llvm/ADT/SmallVector.h
+
+
+#include <cstdlib>
+#include <cstddef>
+#include <type_traits>
+#include <initializer_list>
+#include <cstring>
+#include <stdexcept>
+#include <utility>
+#include <algorithm>
+#include <memory>
+#include <new>
+#include <iterator>
+
+namespace TU {
+
+namespace detail {
+	template <typename T>
+	inline constexpr bool is_relocatable_v = std::is_trivially_copyable_v<T>;
+
+
+	// Just as LLVM to pass as value instead of the reference. It is sometimes cheaper to do this.
+	template <typename T>
+	inline constexpr bool should_pass_by_value = std::is_trivially_copyable_v<T> && sizeof(T)<= 2 * sizeof(void *);
+
+	template <typename T>
+	using value_param_t = std::conditional_t<should_pass_by_value<T>, T, const T&>;
+} // namespace detail
+
+
+template <typename T, std::size_t N>
+struct SmallVector {
+	static_assert(
+		std::is_trivially_copyable_v<T> ||
+		(std::is_nothrow_move_constructible_v<T> && std::is_nothrow_move_assignable_v<T>),
+		"SmallVector<T, N> requires to be trivially copyable, or nothrow move constructible and assignable."
+	);
+	static_assert(N > 0,
+		"N must be greater than 0."
+	);
+
+public:
+	using value_type      = T;
+	using size_type       = std::size_t;
+	using reference       = T&;
+	using const_reference = const T&;
+	using iterator        = T*;
+	using const_iterator  = const T*;
+	using value_param     = detail::value_param_t<T>;
+
+private:
+	size_t size_;
+	size_t capacity_;
+	struct HeapBuf { T *ptr; };
+	union {
+		HeapBuf heapbuf_;
+		alignas(T )std::byte stackbuf_[N * sizeof(T)];
+	};
+
+	T* stack_data() { return reinterpret_cast<T*>(stackbuf_); }
+	const T* stack_data() const { return reinterpret_cast<const T*>(stackbuf_); }
+
+	size_type check_insert_pos(const_iterator pos) const {
+		size_type index = pos - begin();
+		if (index > size_ )throw std::out_of_range("SmallVector::insert: index out of range");
+		return index;
+	}
+
+	size_type next_capacity(size_type min_required) const {
+		size_type grown = capacity_ + capacity_ / 2;
+		return grown > min_required ? grown : min_required;
+	}
+
+	// copied from llvm implementation
+	static void destroy_range(T* first, T* last) noexcept {
+		if constexpr (!std::is_trivially_destructible_v<T>) {
+			for (; first != last; ++first) first->~T();
+		}
+	}
+
+	// move the range [first, first + count) to dest and destroy the original elements
+	static void relocate_range(T* dest, T* first, size_type count) noexcept {
+		if constexpr (detail::is_relocatable_v<T>) {
+			std::memcpy(static_cast<void*>(dest), static_cast<const void*>(first), count * sizeof(T));
+		}
+		else {
+			// move element by element
+			std::uninitialized_move(first,first + count, dest);
+			destroy_range(first, first + count);
+		}
+	}
+
+	static void uninitialized_copy_range(T* dest, const T* src, size_type count) {
+		if constexpr (std::is_trivially_copy_constructible_v<T>) {
+			std::memcpy(static_cast<void*>(dest), static_cast<const void*>(src), count * sizeof(T));
+		}
+		else {
+			std::uninitialized_copy(src, src + count, dest);
+		}
+	}
+
+	void make_gap(size_type index, size_type count) noexcept {
+		T* p = data();
+		if constexpr (detail::is_relocatable_v<T>) {
+			std::memmove(static_cast<void*>(p + index + count), static_cast<const void*>(p + index), (size_ - index) * sizeof(T));
+		}
+		else {
+			// tail is the number of elements to the right of index
+			size_type tail = size_ - index;
+			// if the gap is big enough, move everything to the right without intercepting itself
+			if (tail <= count) relocate_range(p + index + count, p + index, tail);
+			else
+			{
+				// the gap is not big enough.
+				// 1. Move the last elements [size_ - count, size_) to the uninitialized [size_, size_ + count)
+				// 2. Then, move the rest of the elements [index, size_ - count) to [size_ - count, size_)
+				// 3. Finally, destroy the range.
+				// NOTE: It is not enough a move_backward because the move_backward
+				// requires initialized elements to move.
+				std::uninitialized_move(p + size_ - count, p + size_, p + size_);
+				std::move_backward(p + index, p + size_ - count, p + size_);
+				destroy_range(p + index, p + index + count);
+			}
+		}
+	}
+
+	void grow(size_type new_cap) {
+		if constexpr (detail::is_relocatable_v<T>) {
+			if (is_small()) {
+				T* new_data = static_cast<T*>(std::malloc(new_cap * sizeof(T)));
+				if (!new_data) throw std::bad_alloc();
+				std::memcpy(static_cast<void*>(new_data), static_cast<const void*>(stack_data()), size_ * sizeof(T));
+				heapbuf_.ptr = new_data;
+			}
+			else {
+				T* new_data = static_cast<T*>(std::realloc(heapbuf_.ptr, new_cap * sizeof(T)));
+				if (!new_data) throw std::bad_alloc();
+				heapbuf_.ptr = new_data;
+			}
+		}
+		else {
+			T* new_data = static_cast<T*>(std::malloc(new_cap * sizeof(T)));
+			if (!new_data) throw std::bad_alloc();
+			T* old = data();
+			relocate_range(new_data, old, size_);
+			free_heap();
+			heapbuf_.ptr = new_data;
+		}
+		capacity_ = new_cap;
+	}
+
+	void free_heap() {
+		if (!is_small()) std::free(heapbuf_.ptr);
+	}
+
+	void move_from(SmallVector& other) noexcept {
+		if (other.is_small()) {
+			relocate_range(stack_data(), other.stack_data(), other.size_);
+			capacity_ = N;
+		}
+		else {
+			heapbuf_.ptr = other.heapbuf_.ptr;
+			capacity_ = other.capacity_;
+		}
+		size_ = other.size_;
+		other.size_ = 0;
+		other.capacity_ = N;
+	}
+
+public:
+	// Commons
+    bool is_small() const {
+        return capacity_ <= N;
+    }
+
+    bool empty() const { return size_ == 0; }
+
+    size_type size() const { return size_; }
+
+    size_type capacity() const { return capacity_; }
+
+    void reserve(size_type new_cap) {
+        if (new_cap <= capacity_) return;
+        grow(new_cap);
+    }
+
+    // Construction
+    SmallVector() : size_(0), capacity_(N) {}
+
+    explicit SmallVector(size_type count, value_param value = T()) : SmallVector() {
+        resize(count, value);
+    }
+
+    // Copy
+    SmallVector(const SmallVector& other) : SmallVector() {
+        reserve(other.size_);
+        uninitialized_copy_range(data(), other.data(), other.size_);
+        size_ = other.size_;
+    }
+
+    SmallVector(SmallVector&& other) noexcept : SmallVector() {
+        move_from(other);
+    }
+
+    SmallVector& operator=(const SmallVector& other) {
+        if (this == &other) return *this;
+        // destroy-then-copy: if T's copy constructor throws, the vector is left
+        // empty but valid
+        destroy_range(data(), data() + size_);
+        size_ = 0;
+        reserve(other.size_);
+        uninitialized_copy_range(data(), other.data(), other.size_);
+        size_ = other.size_;
+        return *this;
+    }
+
+    SmallVector(std::initializer_list<T> init) : SmallVector() {
+        reserve(init.size());
+        uninitialized_copy_range(data(), init.begin(), init.size());
+        size_ = init.size();
+    }
+
+    SmallVector& operator=(SmallVector&& other) noexcept {
+        if (this == &other) return *this;
+        destroy_range(data(), data() + size_);
+        free_heap();
+        move_from(other);
+        return *this;
+    }
+
+    // Destruction
+    ~SmallVector() {
+        destroy_range(data(), data() + size_);
+        free_heap();
+    }
+
+
+    // Element access
+    T* data() {
+        return is_small()? stack_data() : heapbuf_.ptr;
+    }
+    const T* data() const {
+        return is_small()? stack_data() : heapbuf_.ptr;
+    }
+
+    reference operator[](size_type i) { return data()[i]; }
+    const_reference operator[](size_type i) const { return data()[i]; }
+
+    reference at(size_type i) {
+        if(i >= size_) throw std::out_of_range("SmallVector::at");
+        return data()[i];
+    }
+    const_reference at(size_type i) const {
+        if(i >= size_) throw std::out_of_range("SmallVector::at");
+        return data()[i];
+    }
+
+    reference front() { return data()[0]; }
+    const_reference front() const { return data()[0]; }
+    reference back() { return data()[size_ - 1]; }
+    const_reference back() const { return data()[size_ - 1]; }
+
+    // Iterators
+    iterator begin() { return data(); }
+    const_iterator begin() const { return data(); }
+    iterator end() { return data() + size_; }
+    const_iterator end() const { return data() + size_; }
+
+
+    // Modifiers
+    void clear() noexcept {
+        destroy_range(data(), data() + size_);
+        size_ = 0;
+    }
+
+    void push_back(const T& value) {
+        // copy value before growing
+        T tmp = value;
+        if (size_ == capacity_) grow(next_capacity(capacity_ + 1));
+        new (data() + size_) T(std::move(tmp));
+        ++size_;
+    }
+
+    void push_back(T&& value) {
+        T tmp = std::move(value);
+        if (size_ == capacity_) grow(next_capacity(capacity_ + 1));
+        new (data() + size_) T(std::move(tmp));
+        ++size_;
+    }
+
+    void pop_back() noexcept {
+        if(size_ > 0) {
+            --size_;
+            destroy_range(data() + size_, data() + size_ + 1);
+        }
+    }
+
+    void resize(size_type new_size, value_param fill_value = T()) {
+        if (new_size < size_) {
+            destroy_range(data() + new_size, data() + size_);
+        }
+        else if (new_size > size_) {
+            // copy value before growing
+            T tmp = fill_value;
+            if (new_size > capacity_) grow(next_capacity(new_size));
+            T* p = data();
+            if constexpr (std::is_trivially_copyable_v<T>) {
+                std::fill_n(p + size_, new_size - size_, tmp);
+            }
+        	else {
+                std::uninitialized_fill_n(p + size_, new_size - size_, tmp);
+            }
+        }
+        size_ = new_size;
+    }
+
+    void swap(SmallVector& other) noexcept {
+        if (is_small() && other.is_small()) {
+            if constexpr (std::is_trivially_copyable_v<T>) {
+                alignas(T) std::byte tmp_buf[N * sizeof(T)];
+                std::memcpy(tmp_buf, stackbuf_, size_ * sizeof(T));
+                std::memcpy(stackbuf_, other.stackbuf_, other.size_ * sizeof(T));
+                std::memcpy(other.stackbuf_, tmp_buf, size_ * sizeof(T));
+                std::swap(size_, other.size_);
+            }
+        	else {
+                SmallVector tmp(std::move(*this));
+                *this = std::move(other);
+                other = std::move(tmp);
+            }
+        }
+    	else if (!is_small() && !other.is_small()) {
+            std::swap(heapbuf_.ptr, other.heapbuf_.ptr);
+            std::swap(size_, other.size_);
+            std::swap(capacity_, other.capacity_);
+        }
+    	else {
+            SmallVector tmp(std::move(*this));
+            *this = std::move(other);
+            other = std::move(tmp);
+        }
+    }
+
+    iterator insert(const_iterator pos, const T& value) {
+        size_type index = check_insert_pos(pos);
+
+        // copy value before growing
+        T tmp = value;
+        if (size_ == capacity_) grow(next_capacity(capacity_ + 1));
+
+        make_gap(index, 1);
+        T* p = data();
+        new (p + index) T(std::move(tmp));
+        ++size_;
+        return p + index;
+    }
+
+    iterator insert(const_iterator pos, T&& value) {
+        size_type index = check_insert_pos(pos);
+
+        T tmp = std::move(value);
+        if (size_ == capacity_) grow(next_capacity(capacity_ + 1));
+
+        make_gap(index, 1);
+        T* p = data();
+        new (p + index) T(std::move(tmp));
+        ++size_;
+        return p + index;
+    }
+
+    iterator insert(const_iterator pos, size_type count, value_param value) {
+        size_type index = check_insert_pos(pos);
+        if (count == 0) return begin() + index;
+
+        T tmp = value;
+
+        if (size_ + count > capacity_) grow(size_ + count);
+
+        make_gap(index, count);
+        T* p = data();
+        if constexpr (std::is_trivially_copyable_v<T>) {
+            std::fill_n(p + index, count, tmp);
+        }
+    	else {
+            try {
+                std::uninitialized_fill_n(p + index, count, tmp);
+            }
+    		catch (...) {
+                // T's copy constructor threw halfway: the elements already
+                // shifted past the gap would leave a hole, so drop everything
+                // from the gap onwards (weak guarantee, same policy as folly's
+                // undo_window)
+                destroy_range(p + index + count, p + size_ + count);
+                size_ = index;
+                throw;
+            }
+        }
+        size_ += count;
+        return p + index;
+    }
+
+    template <typename InputIt>
+	requires std::forward_iterator<InputIt>
+    iterator insert(const_iterator pos, InputIt first, InputIt last) {
+        size_type index = check_insert_pos(pos);
+        size_type count  = static_cast<size_type>(std::distance(first, last));
+
+        if (count == 0) return begin() + index;
+
+        if (size_ + count > capacity_) grow(size_ + count);
+
+        make_gap(index, count);
+        T* p = data();
+        if constexpr (std::is_trivially_copyable_v<T>) {
+            for(size_type i = 0; i < count; ++i, ++first) {
+                p[index + i] = *first;
+            }
+        }
+    	else {
+            try {
+                std::uninitialized_copy(first, last, p + index);
+            } catch (...) {
+                destroy_range(p + index + count, p + size_ + count);
+                size_ = index;
+                throw;
+            }
+        }
+        size_ += count;
+        return p + index;
+    }
+
+    iterator insert(const_iterator pos, std::initializer_list<T> ilist) {
+        return insert(pos, ilist.begin(), ilist.end());
+    }
+
+};
+
+
+
+} // namespace TU
+
+
+
+
+
+
+

--- a/tubul/tubul_smallvector.h
+++ b/tubul/tubul_smallvector.h
@@ -2,11 +2,6 @@
 // Created by Alicanto Nano on 13-07-26.
 //
 
-#ifndef TUBUL_TUBUL_SMALLVECTOR_H
-#define TUBUL_TUBUL_SMALLVECTOR_H
-
-#endif // TUBUL_TUBUL_SMALLVECTOR_H
-
 #pragma once
 
 // Reference:
@@ -20,6 +15,7 @@
 
 #include <cstdlib>
 #include <cstddef>
+#include <cstdint>              // SIZE_MAX
 #include <type_traits>
 #include <initializer_list>
 #include <cstring>
@@ -56,6 +52,10 @@ struct SmallVector {
 	static_assert(N > 0,
 		"N must be greater than 0."
 	);
+	// heap growth uses malloc/realloc, which only guarantee max_align_t; over-aligned T would not work.
+	static_assert(alignof(T) <= alignof(std::max_align_t),
+		"SmallVector<T, N> requires alignof(T) <= alignof(std::max_align_t)."
+	);
 
 public:
 	using value_type      = T;
@@ -64,6 +64,8 @@ public:
 	using const_reference = const T&;
 	using iterator        = T*;
 	using const_iterator  = const T*;
+	using reverse_iterator       = std::reverse_iterator<iterator>;
+	using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 	using value_param     = detail::value_param_t<T>;
 
 private:
@@ -72,7 +74,7 @@ private:
 	struct HeapBuf { T *ptr; };
 	union {
 		HeapBuf heapbuf_;
-		alignas(T )std::byte stackbuf_[N * sizeof(T)];
+		alignas(T) std::byte stackbuf_[N * sizeof(T)];
 	};
 
 	T* stack_data() { return reinterpret_cast<T*>(stackbuf_); }
@@ -143,6 +145,7 @@ private:
 	}
 
 	void grow(size_type new_cap) {
+		if (new_cap > SIZE_MAX / sizeof(T)) throw std::length_error("SmallVector: capacity exceeds maximum size");
 		if constexpr (detail::is_relocatable_v<T>) {
 			if (is_small()) {
 				T* new_data = static_cast<T*>(std::malloc(new_cap * sizeof(T)));
@@ -284,6 +287,16 @@ public:
     iterator end() { return data() + size_; }
     const_iterator end() const { return data() + size_; }
 
+    const_iterator cbegin() const { return begin(); }
+    const_iterator cend() const { return end(); }
+
+    reverse_iterator rbegin() { return reverse_iterator(end()); }
+    const_reverse_iterator rbegin() const { return const_reverse_iterator(end()); }
+    reverse_iterator rend() { return reverse_iterator(begin()); }
+    const_reverse_iterator rend() const { return const_reverse_iterator(begin()); }
+    const_reverse_iterator crbegin() const { return const_reverse_iterator(end()); }
+    const_reverse_iterator crend() const { return const_reverse_iterator(begin()); }
+
 
     // Modifiers
     void clear() noexcept {
@@ -304,6 +317,17 @@ public:
         if (size_ == capacity_) grow(next_capacity(capacity_ + 1));
         new (data() + size_) T(std::move(tmp));
         ++size_;
+    }
+
+    template <typename... Args>
+    reference emplace_back(Args&&... args) {
+        // build the value before growing: args may reference existing elements
+        T tmp(std::forward<Args>(args)...);
+        if (size_ == capacity_) grow(next_capacity(capacity_ + 1));
+        T* slot = data() + size_;
+        new (slot) T(std::move(tmp));
+        ++size_;
+        return *slot;
     }
 
     void pop_back() noexcept {
@@ -333,6 +357,7 @@ public:
     }
 
     void swap(SmallVector& other) noexcept {
+        if (this == &other) return;
         if (is_small() && other.is_small()) {
             if constexpr (std::is_trivially_copyable_v<T>) {
                 alignas(T) std::byte tmp_buf[N * sizeof(T)];
@@ -451,7 +476,41 @@ public:
         return insert(pos, ilist.begin(), ilist.end());
     }
 
+    iterator erase(const_iterator pos) {
+        return erase(pos, pos + 1);
+    }
+
+    iterator erase(const_iterator first, const_iterator last) {
+        size_type index = static_cast<size_type>(first - begin());
+        size_type count = static_cast<size_type>(last - first);
+        if (count == 0) return begin() + index;
+
+        T* p = data();
+        if constexpr (detail::is_relocatable_v<T>) {
+            // trivially copyable implies trivially destructible: just shift the tail down
+            std::memmove(static_cast<void*>(p + index), static_cast<const void*>(p + index + count), (size_ - index - count) * sizeof(T));
+        }
+    	else {
+            // move the tail down onto the erased range, then destroy the now-moved-from tail
+            std::move(p + index + count, p + size_, p + index);
+            destroy_range(p + size_ - count, p + size_);
+        }
+        size_ -= count;
+        return p + index;
+    }
+
+    void assign(size_type count, value_param value) {
+        T tmp = value;   // copy before clear: value may alias an element of *this
+        clear();
+        resize(count, tmp);
+    }
+
 };
+
+template <typename T, std::size_t N>
+void swap(SmallVector<T, N>& a, SmallVector<T, N>& b) noexcept {
+    a.swap(b);
+}
 
 
 


### PR DESCRIPTION
Rebase and Squash of the SmallVector and the PODVector. 

Adds `TU::SmallVector<T, N>` with SBO. It is a bit optimized with pod structures.  

PODVector is a heap-only with no SBO, but with optimizations in the 1.5 factor of the next_capacity. The elements can be moved with memcpy, memmove without iterating, creating and moving elements.  